### PR TITLE
refactor: move profile out of the bottom bar

### DIFF
--- a/src/components/Layout/AppChrome.tsx
+++ b/src/components/Layout/AppChrome.tsx
@@ -19,8 +19,9 @@ export function AppChrome({ children }: { children: React.ReactNode }) {
   return (
     <>
       {/* Three navigation surfaces, each owning one breakpoint band:
-          HeaderNav is the brand bar below `lg`, MobileNav the bottom bar
-          below `md`, and SideNav the floating panel from `lg` up. */}
+          HeaderNav is the brand bar below `lg` and carries Profile at every
+          width it is on screen, MobileNav the bottom bar below `md`, and
+          SideNav the floating panel from `lg` up. */}
       <HeaderNav />
       <SideNav />
 

--- a/src/components/Layout/HeaderNav.tsx
+++ b/src/components/Layout/HeaderNav.tsx
@@ -2,26 +2,36 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { User } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
 
 const navigation = [
   { name: 'Standings', href: '/' },
   { name: 'Results', href: '/results' },
   { name: 'Rumblers', href: '/rumblers' },
   { name: 'Squads', href: '/squads' },
-  { name: 'Profile', href: '/profile' },
 ];
 
 /**
- * The top bar: brand on the left, links on the right from `md` up.
+ * The top bar: brand on the left, links from `md` up, profile always.
  *
  * There is deliberately no mobile menu here. `MobileNav` already puts every
  * destination in a fixed bottom bar below `md`, so a hamburger would be a
- * second way to reach the same five links — more chrome, nothing new behind it.
+ * second way to reach the same links — more chrome, nothing new behind it.
+ *
+ * **Profile lives here rather than in the bottom bar.** It is a destination
+ * people open twice a season, and a bottom bar comfortably holds about five
+ * items; spending one of those on the profile crowds out the pages that get
+ * opened every gameweek. It is an avatar button on the right instead, present
+ * at every width below `lg` — at `lg` and up `SideNav` carries it, because
+ * this header is hidden there and nothing else would.
  *
  * **It only sticks from `md` up**, where it carries the links. Below that it is
  * a brand mark and nothing else, so pinning it would spend 64px of a phone
  * screen on a logo while `MobileNav` already keeps every destination one thumb
- * away at the bottom. It scrolls away instead.
+ * away at the bottom. It scrolls away instead — which the profile button can
+ * afford in a way the weekly pages could not.
  *
  * The container matches the one in `src/app/layout.tsx` exactly (`max-w-7xl`
  * and the same padding scale) so the brand lines up with the page heading
@@ -29,6 +39,7 @@ const navigation = [
  */
 export default function HeaderNav() {
   const pathname = usePathname();
+  const isProfile = pathname === '/profile';
 
   return (
     <header className='z-40 rounded-b-xl bg-gradient-to-t from-[#00edfd] from-10% to-[#75fa95] shadow-lg md:sticky md:top-0 lg:hidden'>
@@ -45,28 +56,44 @@ export default function HeaderNav() {
             </span>
           </Link>
 
-          <nav className='hidden md:flex md:gap-1 lg:hidden'>
-            {navigation.map((link) => {
-              const isActive = pathname === link.href;
-              return (
-                <Link
-                  key={link.name}
-                  href={link.href}
-                  aria-current={isActive ? 'page' : undefined}
-                  className={`relative rounded-lg px-4 py-2 text-sm font-semibold transition-all ${
-                    isActive
-                      ? 'bg-[#310639] text-white'
-                      : 'text-[#310639] hover:bg-[#310639]/10'
-                  }`}
-                >
-                  {link.name}
-                  {isActive && (
-                    <span className='absolute bottom-0 left-1/2 h-0.5 w-6 -translate-x-1/2 rounded-full bg-[#310639]' />
-                  )}
-                </Link>
-              );
-            })}
-          </nav>
+          <div className='flex items-center gap-2'>
+            <nav className='hidden md:flex md:gap-1 lg:hidden'>
+              {navigation.map((link) => {
+                const isActive = pathname === link.href;
+                return (
+                  <Link
+                    key={link.name}
+                    href={link.href}
+                    aria-current={isActive ? 'page' : undefined}
+                    className={`relative rounded-lg px-4 py-2 text-sm font-semibold transition-all ${
+                      isActive
+                        ? 'bg-[#310639] text-white'
+                        : 'text-[#310639] hover:bg-[#310639]/10'
+                    }`}
+                  >
+                    {link.name}
+                    {isActive && (
+                      <span className='absolute bottom-0 left-1/2 h-0.5 w-6 -translate-x-1/2 rounded-full bg-[#310639]' />
+                    )}
+                  </Link>
+                );
+              })}
+            </nav>
+
+            <Link
+              href='/profile'
+              aria-label='Profile'
+              aria-current={isProfile ? 'page' : undefined}
+              className={cn(
+                'flex h-10 w-10 items-center justify-center rounded-full transition-colors',
+                isProfile
+                  ? 'bg-[#310639] text-white'
+                  : 'bg-[#310639]/10 text-[#310639] hover:bg-[#310639]/20',
+              )}
+            >
+              <User className='h-5 w-5' />
+            </Link>
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/Layout/MobileNav.tsx
+++ b/src/components/Layout/MobileNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Trophy, BarChart3, Beer, Users, User } from 'lucide-react';
+import { Trophy, BarChart3, Beer, Users } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -10,7 +10,6 @@ const navigation = [
   { name: 'Results', href: '/results', icon: BarChart3 },
   { name: 'Rumblers', href: '/rumblers', icon: Beer },
   { name: 'Squads', href: '/squads', icon: Users },
-  { name: 'Profile', href: '/profile', icon: User },
 ];
 
 /**
@@ -19,7 +18,14 @@ const navigation = [
  * Same `glass` treatment and hairline border, and the gradient appears only on
  * the active item — a 3px rail and a cyan icon — so the loudest thing on a
  * phone screen is the standings rather than the chrome. The two navigations are
- * one design at two orientations; change one and change the other.
+ * one design at two orientations; change the styling of one and change the
+ * other.
+ *
+ * **Their contents deliberately differ by one item.** Profile is not here: a
+ * bottom bar holds about five items before the labels start to crowd, and this
+ * one has to keep room for the weekly pages. It moved to the avatar button in
+ * `HeaderNav`, which is on screen at every width this bar is. `SideNav` still
+ * lists it, because from `lg` up that rail is the only navigation there is.
  *
  * It floats at the sides like `SideNav` does, with a 0.25rem gap beneath it —
  * enough to read as floating, too little to show a strip of page. There is

--- a/src/components/Layout/SideNav.tsx
+++ b/src/components/Layout/SideNav.tsx
@@ -24,9 +24,11 @@ const navigation = [
  * newer generation of `button`/`sheet`/`tooltip`, which would have restyled
  * every button on the site. Five links did not justify that.
  *
- * Below `lg` this is hidden entirely — `MobileNav` already puts the same five
- * destinations in a bottom bar, and two mechanisms for one set of links is one
- * too many.
+ * Below `lg` this is hidden entirely — `MobileNav` and the `HeaderNav` avatar
+ * already reach the same five destinations between them, and two mechanisms for
+ * one set of links is one too many. This rail keeps Profile in the list that
+ * `MobileNav` drops, because from `lg` up the header is hidden and this is the
+ * only navigation on the page.
  *
  * **The gradient is the signature, moved.** It used to run across the full
  * width of the top bar, which made the loudest thing on every page a piece of


### PR DESCRIPTION
## Why

The bottom bar was at five items with more pages coming, and five is roughly where the labels start to crowd. Profile was the weakest occupant: a destination people open twice a season, taking a slot in a rail meant for the pages they check every gameweek.

## What changed

- **`MobileNav`** — four items now (Standings, Results, Rumblers, Squads). They still split the full width, so each gets a wider tap target.
- **`HeaderNav`** — Profile is a 40px circular avatar button on the right, dark purple on the gradient bar, filled solid when `/profile` is active. Present at **every** width below `lg`, not just `md` and up where the text links live, and removed from the text-link row so it is not in two places at `md`.
- **`SideNav`** — list unchanged. From `lg` up the header is hidden, so this rail is the only navigation on the page, and it has the room.
- Docstrings updated in all four Layout files.

## The invariant this breaks, deliberately

`MobileNav`'s docstring said "the two navigations are one design at two orientations; change one and change the other". The contents now differ by one item. Rather than contradict that note silently, it has been rewritten: the invariant covers styling, and the reason the contents diverge is written down.

## Trade-off worth knowing

Below `md` the header is not sticky, so on a phone reaching Profile means scrolling back up. That is the right trade for a twice-a-season page, but it does make Profile less reachable, not just relocated. Making the header sticky below `md` is a one-class change if it bites.

## Verification

`pnpm lint` (0 errors, the same 4 known backlog warnings), `pnpm typecheck` and `pnpm test` (22 passed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)