### PR TITLE
fix: stop the reference fallback shouting in development

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -259,9 +259,19 @@ awards points.
 - **Reference tables are an accelerator, never a source of truth.** `draft_elements` and
   `pl_teams` hold the handful of fields anyone reads out of the 850 KB draft bootstrap.
   Every reader that consults them falls back to the API when the table is empty, stale,
-  incomplete or unreachable, and logs why — so a failed sync makes a page slower, never
-  wrong. The staleness budget is one constant, `REFERENCE_STALE_AFTER_SECONDS` in
-  `src/utils/reference-mapping.ts`, and the cron interval is half of it.
+  incomplete or unreachable, and logs why through `reportUnusableReference` — so a failed
+  sync makes a page slower, never wrong. The staleness budget is one constant,
+  `REFERENCE_STALE_AFTER_SECONDS` in `src/utils/reference-mapping.ts`, and the cron
+  interval is half of it.
+
+  **Locally the tables are stale by construction**, and that is not a bug to fix. Dev
+  reads the sandbox branch (`NEON_CONNECTION_STRING_SANDBOX` wins in
+  `src/server/db/client.ts`) and no cron runs against a laptop, so the sandbox goes stale
+  overnight every night. `reportUnusableReference` therefore warns once per table per
+  process in development and errors on every occurrence in production. Refresh the
+  sandbox by calling `/api/cron/revalidate` on your own dev server with the `CRON_SECRET`
+  bearer token — that process reads the sandbox, so the job writes it.
+
 - **Server-only code lives under `src/server/`** — `db/` (client + Drizzle schema), `data/`
   (the DAL, one module per domain), `actions/` (Server Actions), `auth/` (session and the
   allowlist). Every file there starts with `import 'server-only'`.

--- a/src/utils/draft-elements.ts
+++ b/src/utils/draft-elements.ts
@@ -8,6 +8,7 @@ import { readElements } from '@/server/data/elements';
 import { readTeams } from '@/server/data/pl-teams';
 import {
   isReferenceUsable,
+  reportUnusableReference,
   missingElements,
   toElementDetails,
   toPlTeam,
@@ -268,16 +269,9 @@ function unknownElement(element: ElementId): ElementDetails {
   };
 }
 
-/**
- * A fallback is silent to the reader and loud to the operator.
- *
- * Without the log, a sync can fail for weeks while every page quietly goes on
- * paying full price for a table that exists to avoid it.
- */
+/** Report the fallback, then hand back the `null` every caller returns. */
 function fallingBack(table: string, reason: string, detail?: string): null {
-  console.error(
-    `[reference] ${table} unusable (${reason}${detail ? `: ${detail}` : ''}); falling back to the draft bootstrap.`,
-  );
+  reportUnusableReference(table, reason, detail, 'draft bootstrap');
 
   return null;
 }

--- a/src/utils/pl-teams.ts
+++ b/src/utils/pl-teams.ts
@@ -3,7 +3,11 @@ import 'server-only';
 import { fplApi } from '@/utils/fpl-api';
 import { asTeamCode, type PlTeam, type TeamCode } from '@/interfaces/fpl';
 import { readTeams } from '@/server/data/pl-teams';
-import { isReferenceUsable, toPlTeam } from './reference-mapping';
+import {
+  isReferenceUsable,
+  reportUnusableReference,
+  toPlTeam,
+} from './reference-mapping';
 import { cachedRead } from './cache';
 
 /**
@@ -54,9 +58,11 @@ async function resolvePremierLeagueTeams(): Promise<PlTeam[]> {
       return stored.rows.map(toPlTeam).sort(byName);
     }
 
-    console.error(
-      `[reference] pl_teams unusable (${verdict.reason}${verdict.detail ? `: ${verdict.detail}` : ''}); ` +
-        'falling back to the classic bootstrap.',
+    reportUnusableReference(
+      'pl_teams',
+      verdict.reason,
+      verdict.detail,
+      'classic bootstrap',
     );
   }
 

--- a/src/utils/reference-mapping.ts
+++ b/src/utils/reference-mapping.ts
@@ -280,3 +280,51 @@ export function toPlTeam(row: PlTeamRow): PlTeam {
 export function toPosition(raw: string | undefined): Position {
   return POSITION_ORDER.includes(raw as Position) ? (raw as Position) : 'UNK';
 }
+
+/**
+ * Report that a reference table could not be used, and why.
+ *
+ * **A fallback is silent to the reader and loud to the operator.** The page
+ * renders correctly either way, so without this line a sync can die and every
+ * request goes on quietly paying full price for the table that exists to avoid
+ * it. That is not hypothetical: this log is the only reason we discovered the
+ * cron had never once fired in production.
+ *
+ * **Quieter in development, and only there.** Local reads the sandbox branch
+ * (see `src/server/db/client.ts`), which nothing syncs on a schedule — no cron
+ * runs against a laptop — so its tables go stale overnight *by construction*
+ * and the warning is expected rather than actionable. At `console.error` Next's
+ * dev overlay promotes it to a modal on every render of any page that reads a
+ * reference table, which trains you to dismiss the one signal that matters. So
+ * in development it warns once per table per process and says what to do; in
+ * production nothing changes, and every occurrence is still an error.
+ *
+ * The dedupe key is the table alone, not the table and reason: a second reason
+ * for the same table is the same actionable fact — that table is not syncing.
+ */
+const reportedTables = new Set<string>();
+
+export function reportUnusableReference(
+  table: string,
+  reason: string,
+  detail: string | undefined,
+  fallback: string,
+): void {
+  const message =
+    `[reference] ${table} unusable (${reason}${detail ? `: ${detail}` : ''}); ` +
+    `falling back to the ${fallback}.`;
+
+  if (process.env.NODE_ENV !== 'development') {
+    console.error(message);
+    return;
+  }
+
+  if (reportedTables.has(table)) return;
+  reportedTables.add(table);
+
+  console.warn(
+    `${message} Expected locally: nothing syncs the sandbox branch on a ` +
+      'schedule. Refresh it by calling /api/cron/revalidate on your dev ' +
+      'server with the CRON_SECRET bearer token. Logged once per process.',
+  );
+}


### PR DESCRIPTION
Every page that reads a reference table was opening a "Console Error" modal in
local development, on every render. Nothing was broken.

## Why it happens

Local development reads the **sandbox** branch. `src/server/db/client.ts` prefers
`NEON_CONNECTION_STRING_SANDBOX` over the prod string, deliberately, so the app can
be built against a season that has actually been played while the real one is
pre-season. No cron runs against a laptop, so the sandbox goes stale overnight every
night:

| Branch | `draft_elements` synced | Age when this was found |
| --- | --- | --- |
| Sandbox (what local reads) | 2026-08-14 14:13 | 25.1 hours — stale |
| Prod (what the Vercel cron writes) | 2026-08-15 15:14 | 5 minutes — fresh |

Both readers logged `console.error`, which Next's dev overlay promotes to a modal.

## What changed

The two call sites now share `reportUnusableReference`:

- **Production** — unchanged. `console.error`, every occurrence.
- **Development** — `console.warn`, once per table per process, and the message says
  how to refresh the sandbox.

## What deliberately did not change

The log stays loud in production. It is the only reason we discovered the cron job had
**never once fired** since it was added — the logs held zero requests to
`/api/cron/revalidate`. A fallback that is silent to the reader *and* the operator is
how a sync dies unnoticed for a season. What this removes is the part that made it
useless: a modal on every render of a condition that is expected locally, which trains
you to dismiss the one signal that matters.

The dedupe key is the table alone, not table-and-reason — a second reason for the same
table is the same actionable fact, that it is not syncing.

## Notes

- To refresh the sandbox by hand: call `/api/cron/revalidate` on your own dev server with
  the `CRON_SECRET` bearer token. That process reads the sandbox, so the job writes it.
  Verified — it synced 587 elements and 20 clubs in 3.0s.
- AGENTS.md now records that local staleness is by construction, not a bug to fix.

## Verification

`pnpm lint` (0 errors, the 2 known warnings), `typecheck`, `test` (79 passed),
`format:check`, `build` — all pass.

Not verified: that Next's dev overlay leaves `console.warn` alone rather than promoting
it too. If it does promote it, the once-per-process dedupe still caps it at one
appearance per dev server run instead of one per render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
