### PR TITLE
feat: show the real Premier League table, fixtures and results

### DIFF
--- a/agents/API.md
+++ b/agents/API.md
@@ -1,11 +1,11 @@
 ---
 name: Better Draft — API reference
-last_updated: 2026-08-13
+last_updated: 2026-08-15
 ---
 
 # API.md — Every API We Call, and What Comes Back
 
-Supporting reference doc, read on demand. This is the contract sheet for the two
+Supporting reference doc, read on demand. This is the contract sheet for the three
 Premier League APIs this app reads and the few routes it still exposes. If you are about
 to `fetch()` anything, read the relevant section first — several of these endpoints
 behave in ways the field names do not suggest.
@@ -18,19 +18,20 @@ behave in ways the field names do not suggest.
 
 ---
 
-## The two upstream APIs
+## The three upstream APIs
 
-Both are public, unauthenticated, undocumented, and season-scoped. Neither is versioned,
+All three are public, unauthenticated, undocumented, and season-scoped. None is versioned,
 so treat every shape here as observed rather than guaranteed.
 
-| API                       | Base URL                                | What it gives us                                   |
-| ------------------------- | --------------------------------------- | -------------------------------------------------- |
-| **Draft** (`draft.*`)     | `https://draft.premierleague.com/api`   | The league, its entries, standings, picks, scoring |
-| **Classic** (`fantasy.*`) | `https://fantasy.premierleague.com/api` | Clubs, gameweek metadata, the 380 fixtures         |
+| API                       | Base URL                                     | What it gives us                                   |
+| ------------------------- | -------------------------------------------- | -------------------------------------------------- |
+| **Draft** (`draft.*`)     | `https://draft.premierleague.com/api`        | The league, its entries, standings, picks, scoring |
+| **Classic** (`fantasy.*`) | `https://fantasy.premierleague.com/api`      | Clubs, gameweek metadata, the 380 fixtures         |
+| **Pulse**                 | `https://footballapi.pulselive.com/football` | The **real** league table, fixtures and results    |
 
-Every URL is built by `fplApi` in [`src/utils/fpl-api.ts`](../src/utils/fpl-api.ts).
-That module is the only place upstream URLs are allowed to be written. It is
-`server-only`, so none of this reaches the browser.
+Every URL is built in [`src/utils/fpl-api.ts`](../src/utils/fpl-api.ts) — `fplApi` for the
+two FPL games, `pulseApi` for Pulse. That module is the only place upstream URLs are
+allowed to be written. It is `server-only`, so none of this reaches the browser.
 
 ### The league ID is an environment variable
 
@@ -440,6 +441,177 @@ All 380 fixtures. No consumer in the app; `fplApi.fixtures()` builds the URL.
 ```
 
 `team_h` / `team_a` are `teams[].id` from bootstrap-static.
+
+---
+
+## Pulse API (`footballapi.pulselive.com/football`)
+
+The API behind premierleague.com itself. It answers the one question neither FPL game can:
+**what is the actual league table?**
+
+The classic bootstrap's `teams` objects carry `played`, `win`, `draw`, `loss`, `points` and
+`position` — and leave every one of them at `0`. Deriving a table from finished fixtures
+instead was considered and rejected: it cannot see a points deduction, so it would disagree
+with the official table by a few points in exactly the season where that matters, and it
+would do it silently. **There is deliberately no fallback.** If Pulse is unreachable,
+`/premier-league` says so.
+
+URLs are built by `pulseApi` in [`src/utils/fpl-api.ts`](../src/utils/fpl-api.ts), and read
+through `fetchPulse` — not `fetchUpstream`.
+
+### Every request needs an `Origin` header
+
+```
+Origin: https://www.premierleague.com
+```
+
+No key, no cookie, nothing else. Without it the response is a `403`, which reads as "the
+Premier League page is down" rather than as a missing header — hence `fetchPulse` existing
+at all, so no call site can forget.
+
+> **Unverified from a laptop:** whether Pulse serves Vercel's egress IPs. It works from a
+> development machine and from CI. Check the deployed page after the first production
+> release; if it 403s there and not locally, that is the cause, not the header.
+
+### `compSeasons` is season-scoped — never hard-code it
+
+Exactly like `FPL_LEAGUE_ID`. A new ID is minted every summer.
+
+### `GET /competitions/1/compseasons?pageSize=50`
+
+Competition `1` is the Premier League. Returns `{ pageInfo, content: [{ id, label }] }`.
+
+```json
+{ "id": 841, "label": "English Premier League Season 2026/2027" },
+{ "id": 777, "label": "2025/26" },
+{ "id": 719, "label": "2024/25" }
+```
+
+> **Pick the highest `id`; never parse the label.** Those three lines are one real response.
+> The labels are not one format, and `"2025/26"` sorts above `"English Premier League…"`
+> alphabetically. `newestCompSeasonId()` takes the max, and a test pins it.
+
+### `GET /standings?compSeasons={id}&altIds=true&detail=2`
+
+The league table. `detail=2` is what adds `form`, `annotations` and the home/away splits;
+without it you get positions and totals only.
+
+```json
+{
+  "compSeason": { "id": 841, "label": "…" },
+  "tables": [
+    {
+      "gameWeek": 0,
+      "entries": [
+        {
+          "team": {
+            "name": "Arsenal",
+            "id": 1,
+            "club": { "name": "Arsenal", "abbr": "ARS", "id": 1 },
+            "altIds": { "opta": "t3" }
+          },
+          "position": 1,
+          "startingPosition": 1,
+          "overall": {
+            "played": 0,
+            "won": 0,
+            "drawn": 0,
+            "lost": 0,
+            "goalsFor": 0,
+            "goalsAgainst": 0,
+            "goalsDifference": 0,
+            "points": 0
+          },
+          "home": { "…": "same shape" },
+          "away": { "…": "same shape" },
+          "form": [],
+          "annotations": [{ "type": "Q", "destination": "EU_CL" }]
+        }
+      ]
+    }
+  ]
+}
+```
+
+> **Out of season this returns all 20 clubs on zero, not an empty array.** `entries.length`
+> is `20` in August, so a length or truthy check answers "we have a table" about a page of
+> noughts — the same trap as `elements: {}` on the draft live endpoint. The tell is
+> `tables[0].gameWeek`, which is `0` until the first match. Go through `hasSeasonStarted()`.
+
+- **`form`** is an array of past _fixtures_, not letters. Whether `outcome: "H"` is a win
+  depends on which side of `teams` the club was on — `formFrom()` derives it, and a test
+  pins the away case.
+- **`startingPosition`** is absent pre-season, which is why `movement` is `number | null`
+  rather than defaulting to `0`.
+- **`annotations[].destination`** — the four observed values are not the ones the branding
+  suggests. Verified against two seasons:
+
+  | Code    | Means             | Seen in          |
+  | ------- | ----------------- | ---------------- |
+  | `EU_CL` | Champions League  | 2024/25, 2026/27 |
+  | `EU_EL` | Europa League     | 2026/27          |
+  | `EU_UC` | Conference League | 2024/25          |
+  | `EN_CH` | Relegation        | 2026/27          |
+
+  **Relegation is `EN_CH`** — Pulse names the _destination competition_, the English
+  Championship, not a status. There is no `RELEGATED`, and the Conference League is `EU_UC`
+  rather than `EU_UECL`. `LeagueTable` looks each code up and renders no stripe for one it
+  does not know, so a fifth code appearing is a missing marker, never a wrong one.
+
+### `GET /fixtures?comps=1&compSeasons={id}&pageSize=400&page=0&sort=asc&statuses=U,L,C&altIds=true`
+
+All 380 fixtures in **one** response — at `pageSize=400` the reply is `numPages: 1`, so this
+never needs paging. `statuses=U,L,C` is upcoming, live and complete, which is everything.
+
+```json
+{
+  "gameweek": { "gameweek": 1, "compSeason": { "id": 841 } },
+  "kickoff": { "millis": 1787338800000, "label": "Fri 21 Aug 2026, 20:00 BST" },
+  "teams": [
+    { "team": { "name": "Arsenal", "altIds": { "opta": "t3" } }, "score": 2 },
+    {
+      "team": { "name": "Coventry City", "altIds": { "opta": "t9" } },
+      "score": 0
+    }
+  ],
+  "ground": { "name": "Emirates Stadium", "city": "London" },
+  "status": "C",
+  "outcome": "H",
+  "clock": { "secs": 5700, "label": "90+5'00" },
+  "goals": [
+    { "personId": 25474, "assistId": 67546, "clock": { "label": "74'00" } }
+  ],
+  "id": 128923,
+  "altIds": { "opta": "g2645195" }
+}
+```
+
+- **`teams` is `[home, away]` by position.** Pulse encodes the venue by index, not by a
+  field, so nothing may sort or filter that array in place.
+- **`status`** is `U` upcoming, `L` live, `C` complete — a real state machine, where the
+  classic API spreads the same information over `started`, `finished` and
+  `finished_provisional`.
+- **`score` is absent until kick-off, and `0` is a real score.** Test
+  `typeof score === 'number'`, never truthiness, or a completed goalless draw renders as a
+  fixture yet to be played.
+- **`clock` survives full time** (`90+5'00` on a finished match), so it is only shown while
+  `status` is `L`.
+- **`goals[]` carries `personId`, not a name.** Rendering scorers would need a further
+  lookup; the app does not currently do it.
+- **`altIds.opta`** is `"g" + the classic API's fixture `code``, if a Premier League result
+  ever needs joining to an FPL gameweek.
+
+### The crest join is free
+
+`team.altIds.opta` is `"t"` followed by **exactly** the `teams[].code` the classic bootstrap
+uses — verified across all 20 clubs of the 2026/27 season (`ARS → t3`, `BOU → t91`,
+`BRE → t94`). Since [`clubCrestUrl`](../src/utils/pl-assets.ts) builds
+`…/badges/t{code}.svg`, Pulse hands over the crest key directly.
+
+That is why `/premier-league` makes **no FPL call at all** and needs no club mapping table.
+`optaTeamCode()` recovers the number, and a club whose alt-ID does not parse is dropped
+rather than rendered with a guessed code — the asset host answers a wrong code with `403`,
+which is a broken image and nothing in the log.
 
 ---
 

--- a/src/app/(app)/(onboarded)/premier-league/loading.tsx
+++ b/src/app/(app)/(onboarded)/premier-league/loading.tsx
@@ -1,0 +1,17 @@
+import { PremierLeagueSkeleton } from '@/components/PremierLeagueView/PremierLeagueSkeleton';
+import { SkeletonRegion } from '@/components/SkeletonRegion';
+import { PageShell } from '@/components/Layout/PageShell';
+
+/** Mirrors `page.tsx`'s fallback. Safe because `/premier-league` cannot 404. */
+export default function Loading() {
+  return (
+    <PageShell
+      title='Premier League'
+      subtitle='The real table, fixtures and results'
+    >
+      <SkeletonRegion delayed>
+        <PremierLeagueSkeleton />
+      </SkeletonRegion>
+    </PageShell>
+  );
+}

--- a/src/app/(app)/(onboarded)/premier-league/page.tsx
+++ b/src/app/(app)/(onboarded)/premier-league/page.tsx
@@ -1,0 +1,97 @@
+import { Suspense } from 'react';
+import type { Metadata } from 'next';
+import { AlertTriangle } from 'lucide-react';
+
+import { getPremierLeagueData } from '@/utils/premier-league-data';
+import { PremierLeagueTabs } from '@/components/PremierLeagueView/PremierLeagueTabs';
+import { PremierLeagueSkeleton } from '@/components/PremierLeagueView/PremierLeagueSkeleton';
+import { SkeletonRegion } from '@/components/SkeletonRegion';
+import { PageShell } from '@/components/Layout/PageShell';
+
+export const metadata: Metadata = { title: 'Premier League' };
+
+// Reads live upstream data, so it is never prerendered.
+export const dynamic = 'force-dynamic';
+
+/**
+ * The real Premier League: the actual table, and every fixture and result.
+ *
+ * The one page in the app that touches neither FPL game. Both halves come from
+ * the Pulse API behind premierleague.com, because the classic bootstrap carries
+ * `played`/`won`/`points` on every club and leaves them all at zero — FPL
+ * simply cannot answer "what is the table?".
+ *
+ * `PageShell` paints the heading above the boundary, as everywhere else: the
+ * title is a static string and nobody should wait on an upstream to read it.
+ */
+export default function PremierLeaguePage() {
+  return (
+    <PageShell
+      title='Premier League'
+      subtitle='The real table, fixtures and results'
+    >
+      <Suspense
+        fallback={
+          <SkeletonRegion>
+            <PremierLeagueSkeleton />
+          </SkeletonRegion>
+        }
+      >
+        <PremierLeague />
+      </Suspense>
+    </PageShell>
+  );
+}
+
+async function PremierLeague() {
+  const data = await readOrNull();
+
+  if (!data) return <FeedUnavailable />;
+
+  return <PremierLeagueTabs data={data} />;
+}
+
+/**
+ * The read, and only the read, inside the `try`.
+ *
+ * Splitting it out is not style: JSX constructed inside a `try` puts the
+ * children's own render errors into the same `catch` as the fetch, so a bug in
+ * the table would render "could not be reached" and hide itself. This way the
+ * catch can only ever mean what it says.
+ */
+async function readOrNull() {
+  try {
+    return await getPremierLeagueData();
+  } catch (error) {
+    console.error('[premier-league] Pulse could not be reached.', error);
+
+    return null;
+  }
+}
+
+/**
+ * **Deliberately not a fallback table.** A table derived from finished
+ * fixtures was considered and rejected: it cannot see a points deduction, so
+ * it would disagree with the official table by a few points in exactly the
+ * season where that matters, and it would do it without saying so. An honest
+ * empty state beats a quietly wrong table.
+ */
+function FeedUnavailable() {
+  return (
+    <div className='flex items-start gap-3 rounded-xl border border-border bg-card p-6'>
+      <AlertTriangle
+        className='mt-0.5 h-5 w-5 shrink-0 text-[#f87171]'
+        aria-hidden='true'
+      />
+      <div className='space-y-1'>
+        <p className='text-sm font-semibold text-white'>
+          The Premier League feed could not be reached
+        </p>
+        <p className='text-sm text-white/60'>
+          The table and fixtures come straight from the Premier League. Try
+          again in a few minutes.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/cron/revalidate/route.ts
+++ b/src/app/api/cron/revalidate/route.ts
@@ -40,10 +40,25 @@ import { getPremierLeagueTeams } from '@/utils/pl-teams';
  * Every cache `cachedRead` owns, tagged with its own key.
  *
  * Checked against the `cachedRead` call sites rather than maintained by hand:
- * `gameweek-data.ts`, `squads.ts`, `draft-elements.ts` and `pl-teams.ts`. A
- * tag nobody registers is a silent no-op that reads as coverage.
+ * `gameweek-data.ts`, `squads.ts`, `draft-elements.ts`, `pl-teams.ts` and
+ * `premier-league-data.ts`. A tag nobody registers is a silent no-op that reads
+ * as coverage — and the reverse is worse: adding a `cachedRead` without adding
+ * it here leaves a cache this job claims to clear and does not.
+ *
+ * The two Pulse caches are here for that invariant rather than out of need.
+ * `premier-league` expires on its own every five minutes, well inside the
+ * three-hour interval, and `pulse-compseason` answers a question whose answer
+ * changes once a year. Neither costs anything to drop, and leaving them out
+ * would mean the list above needed a footnote instead of being simply true.
  */
-const TAGS = ['gameweek-data', 'squads', 'draft-elements', 'pl-teams'] as const;
+const TAGS = [
+  'gameweek-data',
+  'squads',
+  'draft-elements',
+  'pl-teams',
+  'premier-league',
+  'pulse-compseason',
+] as const;
 
 /** One step's outcome, so a partial failure cannot be mistaken for success. */
 type StepResult =

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -185,6 +185,43 @@ html {
   -webkit-backdrop-filter: blur(12px);
 }
 
+/*
+ * The same glass, painted *behind* the panel instead of on it.
+ *
+ * `backdrop-filter` blurs what is behind an element, but it also forces that
+ * element and its whole subtree onto one composited layer. Anything in that
+ * subtree landing on a fractional pixel gets resampled along with it — and the
+ * navigation items do: the bar is `left-3 right-3` on a 375px screen, so five
+ * `flex-1` items are 67.8px each and every icon after the first sits on a
+ * fraction. The result is a 20px glyph with 2px strokes redrawn between pixels,
+ * which reads as an out-of-focus icon.
+ *
+ * Moving the filter to a pseudo-element fixes it at the cause: the blur still
+ * samples the page behind the bar, but the icons and labels are no longer
+ * inside the filtered layer, so they rasterise as ordinary text. `isolation`
+ * keeps the `z-index: -1` inside this element rather than sending it behind the
+ * page background, and `border-radius: inherit` keeps the blur inside the
+ * panel's rounded corners.
+ *
+ * Use this for a glass panel with content on it. `.glass` is still right for a
+ * purely decorative surface.
+ */
+.glass-panel {
+  position: relative;
+  isolation: isolate;
+}
+
+.glass-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: rgba(26, 5, 32, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
 .glass-light {
   background: rgba(49, 6, 57, 0.6);
   backdrop-filter: blur(8px);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -203,11 +203,18 @@ html {
  * page background, and `border-radius: inherit` keeps the blur inside the
  * panel's rounded corners.
  *
+ * **It deliberately does not set `position`, and must not.** This rule is
+ * unlayered, and unlayered declarations beat everything in `@layer utilities` —
+ * so a `position: relative` here silently overrode the `fixed` on both
+ * navigations and dropped them into the page flow. The caller owns positioning:
+ * apply this to something already `fixed`, `absolute` or `relative`, and add
+ * Tailwind's `relative` if it is none of those. The pseudo-element needs a
+ * positioned ancestor, so without one the blur escapes to the nearest one.
+ *
  * Use this for a glass panel with content on it. `.glass` is still right for a
  * purely decorative surface.
  */
 .glass-panel {
-  position: relative;
   isolation: isolate;
 }
 

--- a/src/components/GameweekSelector.tsx
+++ b/src/components/GameweekSelector.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useEffect, useRef } from 'react';
+
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 
@@ -12,12 +14,66 @@ interface GameweekSelectorProps {
  * A row of gameweek pills. Deliberately unlabelled: a strip of "GW 1, GW 2 …"
  * with one highlighted explains itself, and the label was stealing a line of
  * vertical space above the fold on mobile.
+ *
+ * **The selected pill is scrolled into view.** Without it a strip that opens on
+ * anything past the first few gameweeks opens on a highlight nobody can see —
+ * the strip looks like it starts at GW 1 and the selection appears to have been
+ * lost. It matters most on the Premier League page, which has all 38 from the
+ * first day of the season, but the results and rumblers strips grow into the
+ * same problem by about November.
  */
 export function GameweekSelector({
   gameweeks,
   selectedGameweek,
   onSelectGameweek,
 }: GameweekSelectorProps) {
+  const selectedRef = useRef<HTMLButtonElement>(null);
+  // The first pass is the initial paint, which must not animate: a strip that
+  // slides into position on arrival reads as the page still loading. Every
+  // pass after it is a click, where the movement is the feedback.
+  const hasScrolled = useRef(false);
+
+  useEffect(() => {
+    const pill = selectedRef.current;
+
+    if (!pill) return;
+
+    // Radix scrolls its own viewport, not the `ScrollArea` root, so the
+    // element that owns `scrollLeft` has to be found rather than assumed.
+    const viewport = pill.closest<HTMLElement>(
+      '[data-radix-scroll-area-viewport]',
+    );
+
+    if (!viewport) return;
+
+    // Measured from the rendered boxes rather than `offsetLeft`, which is
+    // relative to whichever ancestor happens to be positioned — here the
+    // `ScrollArea` root, and that is a coincidence of the primitive's styling
+    // rather than something this component should depend on.
+    const pillBox = pill.getBoundingClientRect();
+    const viewportBox = viewport.getBoundingClientRect();
+    const centred =
+      pillBox.left - viewportBox.left - (viewportBox.width - pillBox.width) / 2;
+
+    // Nothing to do when the pill is already fully in view: scrolling a strip
+    // that did not need it turns every click into a small lurch.
+    const fullyVisible =
+      pillBox.left >= viewportBox.left && pillBox.right <= viewportBox.right;
+
+    if (fullyVisible && hasScrolled.current) return;
+
+    const reduceMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+
+    viewport.scrollTo({
+      left: viewport.scrollLeft + centred,
+      behavior: hasScrolled.current && !reduceMotion ? 'smooth' : 'auto',
+    });
+
+    hasScrolled.current = true;
+  }, [selectedGameweek]);
+
   return (
     <div className='w-full'>
       <ScrollArea className='w-full rounded-lg whitespace-nowrap'>
@@ -33,6 +89,7 @@ export function GameweekSelector({
           {gameweeks.map((gameweek) => (
             <ToggleGroupItem
               key={gameweek}
+              ref={gameweek === selectedGameweek ? selectedRef : undefined}
               value={String(gameweek)}
               className='min-w-[70px] rounded-lg border border-white/20 bg-[#2a0d33] px-3 py-2 text-xs font-semibold text-white transition-all hover:border-[#00edfd]/50 hover:bg-[#3d1a4d] hover:text-[#00edfd] data-[state=on]:border-[#00edfd] data-[state=on]:bg-[#00edfd]/20 data-[state=on]:text-[#00edfd] md:text-sm'
             >

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -62,7 +62,7 @@ export default function Footer() {
   return (
     <footer className='hidden md:block lg:pl-64'>
       <div className='mx-auto w-full max-w-7xl px-4 pb-4 sm:px-6 lg:px-8'>
-        <div className='glass rounded-xl border border-white/10 px-6 py-4'>
+        <div className='glass-panel rounded-xl border border-white/10 px-6 py-4'>
           <div className='flex flex-col items-center gap-4 md:flex-row md:justify-between'>
             <p className='text-center text-xs font-medium text-white/50'>
               &copy; {year} Theunis Duminy. For the lads. All rights reserved.

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -62,7 +62,10 @@ export default function Footer() {
   return (
     <footer className='hidden md:block lg:pl-64'>
       <div className='mx-auto w-full max-w-7xl px-4 pb-4 sm:px-6 lg:px-8'>
-        <div className='glass-panel rounded-xl border border-white/10 px-6 py-4'>
+        {/* `relative` is required beside `glass-panel`: the blur lives on a
+            `::before`, which needs a positioned ancestor. The two navigations
+            get it from being `fixed`; this block is in normal flow. */}
+        <div className='glass-panel relative rounded-xl border border-white/10 px-6 py-4'>
           <div className='flex flex-col items-center gap-4 md:flex-row md:justify-between'>
             <p className='text-center text-xs font-medium text-white/50'>
               &copy; {year} Theunis Duminy. For the lads. All rights reserved.

--- a/src/components/Layout/HeaderNav.tsx
+++ b/src/components/Layout/HeaderNav.tsx
@@ -6,11 +6,16 @@ import { User } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * The same five as `MobileNav`, in the same order. This strip only shows at
+ * `md`, where there is room for the full name rather than the bar's "Prem".
+ */
 const navigation = [
   { name: 'Standings', href: '/' },
   { name: 'Results', href: '/results' },
   { name: 'Rumblers', href: '/rumblers' },
   { name: 'Squads', href: '/squads' },
+  { name: 'Premier League', href: '/premier-league' },
 ];
 
 /**

--- a/src/components/Layout/MobileNav.tsx
+++ b/src/components/Layout/MobileNav.tsx
@@ -1,15 +1,32 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Trophy, BarChart3, Beer, Users } from 'lucide-react';
+import { Trophy, BarChart3, Beer, Users, Shield } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * **Five is the ceiling, and this is the fifth.** Do not add a sixth.
+ *
+ * At 375px the bar has ~339px of usable width, so five items are ~68px each —
+ * enough for a 20px icon and a 10px label, and nothing spare. A sixth drops
+ * each to ~56px, which is under the 44px tap target once the gaps are taken
+ * out and narrower than the word "Standings" at any legible size.
+ *
+ * So the next destination after Premier League is not a nav change, it is an
+ * information-architecture decision: either it belongs inside one of these
+ * five, or this becomes four items and a "More" sheet. Squeezing a sixth in is
+ * the one option that is already ruled out.
+ *
+ * "Prem" rather than "Premier League" for the same reason — it is the longest
+ * label the slot takes. `SideNav` has the room and spells it out.
+ */
 const navigation = [
   { name: 'Standings', href: '/', icon: Trophy },
   { name: 'Results', href: '/results', icon: BarChart3 },
   { name: 'Rumblers', href: '/rumblers', icon: Beer },
   { name: 'Squads', href: '/squads', icon: Users },
+  { name: 'Prem', href: '/premier-league', icon: Shield },
 ];
 
 /**
@@ -40,7 +57,10 @@ export default function MobileNav() {
   return (
     <nav
       aria-label='Main'
-      className='glass fixed right-3 bottom-1 left-3 z-50 rounded-2xl border border-white/10 shadow-[0_-8px_32px_rgba(0,0,0,0.4)] md:hidden'
+      // `glass-panel`, not `glass`: the blur is painted behind the bar rather
+      // than on it, so the icons are not inside a composited, resampled layer.
+      // See the comment on the utility in `globals.css`.
+      className='glass-panel fixed right-3 bottom-1 left-3 z-50 rounded-2xl border border-white/10 shadow-[0_-8px_32px_rgba(0,0,0,0.4)] md:hidden'
     >
       <ul className='mx-auto flex h-16 max-w-md items-stretch justify-around p-1.5'>
         {navigation.map((link) => {
@@ -65,10 +85,18 @@ export default function MobileNav() {
                     className='absolute inset-x-3 bottom-1 h-[3px] rounded-full bg-gradient-to-r from-[#00edfd] to-[#75fa95]'
                   />
                 )}
+                {/* Solid white when inactive, not a percentage of it.
+                    Two earlier attempts dimmed it — `white/40`, then inheriting
+                    the link's `white/60` — and both read as an out-of-focus
+                    icon rather than a quiet one: a 20px glyph drawn in 2px
+                    strokes has no weight to spare, so opacity eats the shape
+                    itself rather than just its emphasis. The hierarchy lives in
+                    the label, which stays at `white/60`, and in the active
+                    item's colour and rail. */}
                 <Icon
                   className={cn(
                     'h-5 w-5 transition-colors',
-                    isActive ? 'text-[#00edfd]' : 'text-white/40',
+                    isActive ? 'text-[#00edfd]' : 'text-white',
                   )}
                 />
                 <span className='text-[10px] font-semibold'>{link.name}</span>

--- a/src/components/Layout/SideNav.tsx
+++ b/src/components/Layout/SideNav.tsx
@@ -2,15 +2,21 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Trophy, BarChart3, Beer, Users, User } from 'lucide-react';
+import { Trophy, BarChart3, Beer, Users, Shield, User } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Six here against `MobileNav`'s five: this rail has vertical room, so it
+ * carries Profile as well and spells "Premier League" out in full where the
+ * bottom bar has to say "Prem".
+ */
 const navigation = [
   { name: 'Standings', href: '/', icon: Trophy },
   { name: 'Results', href: '/results', icon: BarChart3 },
   { name: 'Rumblers', href: '/rumblers', icon: Beer },
   { name: 'Squads', href: '/squads', icon: Users },
+  { name: 'Premier League', href: '/premier-league', icon: Shield },
   { name: 'Profile', href: '/profile', icon: User },
 ];
 
@@ -42,7 +48,9 @@ export function SideNav() {
   return (
     <nav
       aria-label='Main'
-      className='glass fixed top-4 bottom-4 left-4 z-40 hidden w-56 flex-col rounded-2xl border border-white/10 p-3 shadow-[0_8px_32px_rgba(0,0,0,0.4)] lg:flex'
+      // `glass-panel` for the same reason as `MobileNav`: the blur goes behind
+      // the rail, not on it, so its contents stay out of the composited layer.
+      className='glass-panel fixed top-4 bottom-4 left-4 z-40 hidden w-56 flex-col rounded-2xl border border-white/10 p-3 shadow-[0_8px_32px_rgba(0,0,0,0.4)] lg:flex'
     >
       <Link
         href='/'
@@ -78,10 +86,14 @@ export function SideNav() {
                     className='absolute top-2 bottom-2 -left-3 w-[3px] rounded-full bg-gradient-to-b from-[#00edfd] to-[#75fa95]'
                   />
                 )}
+                {/* Solid white when inactive, matching `MobileNav` — see the
+                    comment there for why an icon this small cannot carry its
+                    hierarchy in opacity. The two navigations are one design; a
+                    treatment that only holds on one of them is a drift. */}
                 <Icon
                   className={cn(
                     'h-4 w-4 shrink-0 transition-colors',
-                    isActive ? 'text-[#00edfd]' : 'text-white/40',
+                    isActive ? 'text-[#00edfd]' : 'text-white',
                   )}
                 />
                 {link.name}

--- a/src/components/PremierLeagueView/FixtureBoard.tsx
+++ b/src/components/PremierLeagueView/FixtureBoard.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ClubCrest } from '@/components/ClubCrest';
+import { GameweekSelector } from '@/components/GameweekSelector';
+import { cn } from '@/lib/utils';
+import type { GameweekFixtures, PlFixture } from '@/interfaces/premier-league';
+
+/**
+ * Fixtures and results, one gameweek at a time.
+ *
+ * A client component for the gameweek state only — all 38 weeks arrive as a
+ * prop, already grouped and sorted on the server, so stepping between them is
+ * instant and costs no request. That is the whole reason the page fetches all
+ * 380 fixtures in one go rather than one gameweek at a time: Pulse returns the
+ * lot in a single response, so paging it would be more calls for less.
+ *
+ * **Results and fixtures are the same object here, not two tabs.** A gameweek
+ * in progress is half played, and splitting it would put the same round in two
+ * places. The score column carries the state instead: a kick-off time before,
+ * a live minute during, the score after.
+ */
+export function FixtureBoard({
+  gameweeks,
+  initialGameweek,
+}: {
+  gameweeks: GameweekFixtures[];
+  /** Where to land: live, else next up, else the last. Decided on the server. */
+  initialGameweek: number;
+}) {
+  const [selected, setSelected] = useState(initialGameweek);
+
+  if (gameweeks.length === 0) {
+    return (
+      <p className='rounded-xl border border-border bg-card p-6 text-center text-sm text-white/60'>
+        No fixtures have been published yet.
+      </p>
+    );
+  }
+
+  // A gameweek that vanished from upstream between render and click would
+  // otherwise blank the list, so fall back to the first rather than to nothing.
+  const current =
+    gameweeks.find((week) => week.gameweek === selected) ?? gameweeks[0];
+
+  return (
+    <div className='space-y-4'>
+      {/* The same pill strip the results page uses, rather than the prev/next
+          pair this started with: 38 gameweeks is a lot of tapping to reach
+          December, and the strip lets someone jump straight there. It is
+          `GameweekSelector`, unchanged — a second scroller that looked almost
+          like the first is exactly what the shared component exists to stop. */}
+      <GameweekSelector
+        gameweeks={gameweeks.map((week) => week.gameweek)}
+        selectedGameweek={current.gameweek}
+        onSelectGameweek={setSelected}
+      />
+
+      <p className='text-xs text-white/50'>{summarise(current.fixtures)}</p>
+
+      <ul className='divide-y divide-border overflow-hidden rounded-xl border border-border bg-card'>
+        {current.fixtures.map((fixture) => (
+          <li key={fixture.id}>
+            <FixtureRow fixture={fixture} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** "10 fixtures", plus "· 3 live" or "· 6 played" once there is something to say. */
+function summarise(fixtures: PlFixture[]): string {
+  const played = fixtures.filter((fixture) => fixture.status === 'C').length;
+  const live = fixtures.filter((fixture) => fixture.status === 'L').length;
+  const count = `${fixtures.length} ${fixtures.length === 1 ? 'fixture' : 'fixtures'}`;
+
+  if (live > 0) return `${count} · ${live} live`;
+  if (played > 0) return `${count} · ${played} played`;
+
+  return count;
+}
+
+function FixtureRow({ fixture }: { fixture: PlFixture }) {
+  const played = fixture.homeScore !== null && fixture.awayScore !== null;
+
+  return (
+    <div className='flex items-center gap-2 px-3 py-3 sm:gap-4 sm:px-4'>
+      {/* Home: name then crest, so the two crests meet in the middle either
+          side of the score, the way a fixture list reads on a screen. */}
+      <div className='flex flex-1 items-center justify-end gap-2 text-right'>
+        <span className={cn('truncate text-sm', outcomeWeight(fixture, 'H'))}>
+          <span className='sm:hidden'>{fixture.home.abbr}</span>
+          <span className='hidden sm:inline'>{fixture.home.shortName}</span>
+        </span>
+        <ClubCrest code={fixture.home.code} name={fixture.home.name} />
+      </div>
+
+      <Scoreline fixture={fixture} played={played} />
+
+      <div className='flex flex-1 items-center gap-2'>
+        <ClubCrest code={fixture.away.code} name={fixture.away.name} />
+        <span className={cn('truncate text-sm', outcomeWeight(fixture, 'A'))}>
+          <span className='sm:hidden'>{fixture.away.abbr}</span>
+          <span className='hidden sm:inline'>{fixture.away.shortName}</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The middle column: a score, a live minute, or a kick-off time.
+ *
+ * Fixed width so the crests either side line up down the list rather than
+ * shuffling with the length of each label.
+ */
+function Scoreline({
+  fixture,
+  played,
+}: {
+  fixture: PlFixture;
+  played: boolean;
+}) {
+  if (played) {
+    return (
+      <div className='flex w-20 shrink-0 flex-col items-center sm:w-24'>
+        <span className='text-sm font-bold text-white tabular-nums'>
+          {fixture.homeScore} – {fixture.awayScore}
+        </span>
+        {fixture.status === 'L' && fixture.clockLabel && (
+          <span className='text-[10px] font-semibold text-[#75fa95]'>
+            {fixture.clockLabel}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex w-20 shrink-0 flex-col items-center sm:w-24'>
+      <span className='text-xs font-medium text-white/60 tabular-nums'>
+        {kickoffTime(fixture)}
+      </span>
+      <span className='text-[10px] text-white/35'>{kickoffDay(fixture)}</span>
+    </div>
+  );
+}
+
+/**
+ * Both halves come out of Pulse's own `"Sat 22 Aug 2026, 12:30 BST"`, split on
+ * the comma, rather than from a `Date` — formatting the epoch here would render
+ * the server's timezone on the first paint and the reader's after hydration,
+ * which is a visible flip and a hydration warning. Pulse has already localised
+ * it to UK time, which is the right zone for a Premier League kick-off anyway.
+ */
+function kickoffTime(fixture: PlFixture): string {
+  const time = fixture.kickoffLabel?.split(', ')[1];
+
+  return time ?? 'TBC';
+}
+
+function kickoffDay(fixture: PlFixture): string {
+  const day = fixture.kickoffLabel?.split(', ')[0];
+
+  return day ?? '';
+}
+
+/** The winning side is the one in white; the loser dims. */
+function outcomeWeight(fixture: PlFixture, side: 'H' | 'A'): string {
+  if (!fixture.outcome || fixture.status === 'U') return 'text-white/80';
+  if (fixture.outcome === 'D') return 'text-white/80';
+
+  return fixture.outcome === side
+    ? 'font-semibold text-white'
+    : 'text-white/45';
+}

--- a/src/components/PremierLeagueView/LeagueTable.tsx
+++ b/src/components/PremierLeagueView/LeagueTable.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { ArrowDown, ArrowUp } from 'lucide-react';
+
+import { ClubCrest } from '@/components/ClubCrest';
+import { BaseTable, type TableColumn } from '@/components/TableView/base-table';
+import { cn } from '@/lib/utils';
+import type { FormResult, LeagueTableRow } from '@/interfaces/premier-league';
+
+/**
+ * The Premier League table.
+ *
+ * Built on `BaseTable`, the same primitive the standings board uses, so the two
+ * tables on this site share a row height, a hover shape and one way of hiding a
+ * column at a breakpoint. It was briefly hand-rolled over the `ui/table`
+ * primitives and that was the wrong call: it meant a second table on the site
+ * that looked almost, but not quite, like the first.
+ *
+ * **Two column sets, one config.** A phone gets position, club, played, goal
+ * difference and points, which is what anyone reads a table for. W/D/L appear
+ * from `sm`, goals for and against from `md`, the form guide from `lg` — all
+ * through `hideBelow`, which keeps each header and its cells in step.
+ *
+ * The qualification stripe is a left border on the first cell rather than a
+ * border on the row: a `<tr>` border does not paint reliably under
+ * `border-collapse`, and `BaseTable` gives per-cell classes for exactly this.
+ */
+
+/**
+ * What each Pulse annotation means, and the colour it earns.
+ *
+ * **These four codes are observed, not guessed.** The 2024/25 table carries
+ * `EU_CL` and `EU_UC`; the 2026/27 one carries `EU_CL`, `EU_EL` and `EN_CH`.
+ * Relegation is `EN_CH` — the destination is the *English Championship*, not a
+ * status called "relegated" — and the Conference League is `EU_UC`, not the
+ * `EU_UECL` its own branding suggests. An unrecognised code renders no stripe
+ * and no legend entry rather than a wrong one, which is why `railFor` looks the
+ * code up instead of assuming.
+ */
+const ANNOTATION_STYLES: Record<
+  string,
+  { rail: string; swatch: string; label: string }
+> = {
+  EU_CL: {
+    rail: 'border-l-[3px] border-l-[#00edfd]',
+    swatch: 'bg-[#00edfd]',
+    label: 'Champions League',
+  },
+  EU_EL: {
+    rail: 'border-l-[3px] border-l-[#75fa95]',
+    swatch: 'bg-[#75fa95]',
+    label: 'Europa League',
+  },
+  EU_UC: {
+    rail: 'border-l-[3px] border-l-[#75fa95]/60',
+    swatch: 'bg-[#75fa95]/60',
+    label: 'Conference League',
+  },
+  EN_CH: {
+    rail: 'border-l-[3px] border-l-[#f87171]',
+    swatch: 'bg-[#f87171]',
+    label: 'Relegation',
+  },
+};
+
+const FORM_STYLES: Record<FormResult, string> = {
+  W: 'bg-[#75fa95]/20 text-[#75fa95]',
+  D: 'bg-white/10 text-white/60',
+  L: 'bg-[#f87171]/20 text-[#f87171]',
+};
+
+const FORM_LABELS: Record<FormResult, string> = {
+  W: 'Won',
+  D: 'Drew',
+  L: 'Lost',
+};
+
+export function LeagueTable({ rows }: { rows: LeagueTableRow[] }) {
+  const legend = visibleAnnotations(rows);
+
+  return (
+    <div className='space-y-3'>
+      <BaseTable
+        title=''
+        data={rows}
+        columns={leagueTableColumns()}
+        emptyMessage='The table is not available right now.'
+        getRowKey={(row) => row.club.code}
+      />
+
+      {legend.length > 0 && (
+        <ul className='flex flex-wrap gap-x-4 gap-y-1.5'>
+          {legend.map((note) => (
+            <li
+              key={note}
+              className='flex items-center gap-2 text-xs text-white/50'
+            >
+              <span
+                aria-hidden='true'
+                className={cn(
+                  'h-2.5 w-[3px] rounded-full',
+                  ANNOTATION_STYLES[note].swatch,
+                )}
+              />
+              {ANNOTATION_STYLES[note].label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function leagueTableColumns(): TableColumn<LeagueTableRow>[] {
+  return [
+    {
+      header: '#',
+      key: (row) => row.position,
+      align: 'center',
+      width: 'w-[12%] md:w-[7%]',
+      // The stripe rides on this cell, so it lands at the left edge of the row.
+      cellClassName: (row) => railFor(row) ?? '',
+    },
+    {
+      header: 'Club',
+      key: (row) => (
+        <div className='flex items-center gap-2.5'>
+          <ClubCrest code={row.club.code} name={row.club.name} />
+          <span className='truncate font-medium text-white'>
+            {/* "Nottingham Forest" needs seventeen characters; the short name
+                is what a broadcast graphic uses and what fits a phone. */}
+            <span className='sm:hidden'>{row.club.shortName}</span>
+            <span className='hidden sm:inline'>{row.club.name}</span>
+          </span>
+          <Movement places={row.movement} />
+        </div>
+      ),
+      width: 'w-[40%] md:w-[26%]',
+    },
+    numeric('P', (row) => row.played, 'w-[12%] md:w-[6%]'),
+    numeric('W', (row) => row.won, 'md:w-[6%]', 'sm'),
+    numeric('D', (row) => row.drawn, 'md:w-[6%]', 'sm'),
+    numeric('L', (row) => row.lost, 'md:w-[6%]', 'sm'),
+    numeric('GF', (row) => row.goalsFor, 'md:w-[6%]', 'md'),
+    numeric('GA', (row) => row.goalsAgainst, 'md:w-[6%]', 'md'),
+    numeric(
+      'GD',
+      (row) => `${row.goalDifference > 0 ? '+' : ''}${row.goalDifference}`,
+      'w-[16%] md:w-[7%]',
+    ),
+    {
+      header: 'Pts',
+      key: (row) => row.points,
+      align: 'center',
+      width: 'w-[20%] md:w-[8%]',
+      cellClassName: () => 'font-bold text-white tabular-nums',
+    },
+    {
+      header: 'Form',
+      key: (row) => <FormGuide form={row.form} club={row.club.name} />,
+      width: 'lg:w-[16%]',
+      hideBelow: 'lg',
+    },
+  ];
+}
+
+/** A right-aligned count column, which is most of this table. */
+function numeric(
+  header: string,
+  read: (row: LeagueTableRow) => React.ReactNode,
+  width: string,
+  hideBelow?: 'sm' | 'md' | 'lg',
+): TableColumn<LeagueTableRow> {
+  return {
+    header,
+    key: read,
+    align: 'center',
+    width,
+    hideBelow,
+    cellClassName: () => 'text-white/70 tabular-nums',
+  };
+}
+
+/** The border class for a row's first annotation, if it has one we know. */
+function railFor(row: LeagueTableRow): string | null {
+  for (const note of row.annotations) {
+    const style = ANNOTATION_STYLES[note];
+
+    if (style) return style.rail;
+  }
+
+  return null;
+}
+
+/** Only explain the markers actually on screen. */
+function visibleAnnotations(rows: LeagueTableRow[]): string[] {
+  const seen = new Set<string>();
+
+  for (const row of rows) {
+    for (const note of row.annotations) {
+      if (ANNOTATION_STYLES[note]) seen.add(note);
+    }
+  }
+
+  return [...seen];
+}
+
+function FormGuide({ form, club }: { form: FormResult[]; club: string }) {
+  if (form.length === 0) {
+    return <span className='text-xs text-white/30'>—</span>;
+  }
+
+  return (
+    <div className='flex gap-1'>
+      {form.map((result, index) => (
+        <span
+          // Form is a fixed-length ordered run of five letters with no id of
+          // its own, and it re-renders wholesale on every refresh, so the index
+          // is a stable enough key here.
+          key={index}
+          title={`${FORM_LABELS[result]} — ${club}`}
+          className={cn(
+            'flex h-5 w-5 items-center justify-center rounded text-[10px] font-bold',
+            FORM_STYLES[result],
+          )}
+        >
+          {result}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function Movement({ places }: { places: number | null }) {
+  if (places === null || places === 0) return null;
+
+  const up = places > 0;
+  const Icon = up ? ArrowUp : ArrowDown;
+
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center text-[10px] font-semibold',
+        up ? 'text-[#75fa95]' : 'text-[#f87171]',
+      )}
+    >
+      <Icon className='h-3 w-3' aria-hidden='true' />
+      <span className='sr-only'>
+        {up ? 'Up' : 'Down'} {Math.abs(places)} since the gameweek began
+      </span>
+    </span>
+  );
+}

--- a/src/components/PremierLeagueView/PremierLeagueSkeleton.tsx
+++ b/src/components/PremierLeagueView/PremierLeagueSkeleton.tsx
@@ -1,0 +1,59 @@
+import { TableSkeleton } from '@/components/TableView/table-skeleton';
+import { SECTION_TABS_STRIP_CLASS } from '@/components/shapes';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/**
+ * Loading shape for `/premier-league`.
+ *
+ * Mirrors the default tab only — the table — because that is the one rendered
+ * before the reader touches anything. Shared by the page's Suspense fallback
+ * and its `loading.tsx`, so a soft navigation and a stream look identical.
+ *
+ * Twenty rows is not a guess: the Premier League has twenty clubs, so the real
+ * table lands at exactly this height and the handover does not shift. It goes
+ * through `TableSkeleton` for the same reason the table itself goes through
+ * `BaseTable` — one row height and one set of column widths, defined once.
+ */
+
+/** The real table's widths, in order. Kept beside it in `LeagueTable`. */
+const COLUMN_WIDTHS = [
+  'w-[12%] md:w-[7%]',
+  'w-[40%] md:w-[26%]',
+  'w-[12%] md:w-[6%]',
+  'md:w-[6%]',
+  'md:w-[6%]',
+  'md:w-[6%]',
+  'md:w-[6%]',
+  'md:w-[6%]',
+  'w-[16%] md:w-[7%]',
+  'w-[20%] md:w-[8%]',
+  'lg:w-[16%]',
+];
+
+/**
+ * W, D, L, GF and GA are gone below `md`, and so is the form guide.
+ *
+ * `TableSkeleton` only offers a single `md` cut where the real table hides
+ * W/D/L at `sm` and the form at `lg`. The mismatch is one column either side
+ * of `md` on a narrow tablet, for the length of one load — worth it against a
+ * second skeleton implementation that would drift from this one.
+ */
+const HIDDEN_BELOW_MD = [3, 4, 5, 6, 7, 10];
+
+export function PremierLeagueSkeleton() {
+  return (
+    <div className='space-y-4'>
+      <Skeleton className={SECTION_TABS_STRIP_CLASS} />
+
+      <TableSkeleton
+        columns={COLUMN_WIDTHS.length}
+        rows={20}
+        // The real first column is a plain position number, not the rank badge
+        // the standings board leads with.
+        leadingBadge={false}
+        hideBelowMd={HIDDEN_BELOW_MD}
+        widths={COLUMN_WIDTHS}
+      />
+    </div>
+  );
+}

--- a/src/components/PremierLeagueView/PremierLeagueTabs.tsx
+++ b/src/components/PremierLeagueView/PremierLeagueTabs.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { CalendarDays, Table2 } from 'lucide-react';
+
+import { SectionTabs } from '@/components/SectionTabs';
+import { LeagueTable } from './LeagueTable';
+import { FixtureBoard } from './FixtureBoard';
+import type { PremierLeagueData } from '@/interfaces/premier-league';
+
+/**
+ * The table and the fixture list, behind the same strip the standings and
+ * rumblers pages use.
+ *
+ * The table leads. Someone opening this page has a position in mind more often
+ * than a kick-off time, and the fixture board is the one that costs a tap to
+ * get back from because it holds its own gameweek state.
+ *
+ * `'use client'` for the tab state, which also makes both panels client
+ * components. That is no loss here: `FixtureBoard` is one already, and
+ * `LeagueTable` is pure markup over data that arrives as a prop.
+ */
+export function PremierLeagueTabs({ data }: { data: PremierLeagueData }) {
+  return (
+    <SectionTabs
+      defaultValue='table'
+      tabs={[
+        {
+          value: 'table',
+          label: 'Table',
+          icon: Table2,
+          content: <LeagueTable rows={data.table} />,
+        },
+        {
+          value: 'fixtures',
+          // "Matches" rather than "Fixtures", because this one tab is both:
+          // it opens on the current gameweek and scrolls back into played
+          // ones, where the kick-off time becomes the score. "Fixtures" alone
+          // made the results look missing, and spelling both out ran the
+          // trigger to the edge of its half of the strip on a phone. A match
+          // is a match whether it has been played or not.
+          label: 'Matches',
+          icon: CalendarDays,
+          content: (
+            <FixtureBoard
+              gameweeks={data.gameweeks}
+              initialGameweek={data.currentGameweek}
+            />
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/TableView/table-configs.tsx
+++ b/src/components/TableView/table-configs.tsx
@@ -245,7 +245,13 @@ export function draftResultsColumns(
         <Button
           variant='outline'
           size='sm'
-          className='h-8 gap-1.5 border-white/10 bg-white/5 px-2 text-xs text-white/70 hover:border-[#00edfd]/50 hover:text-[#00edfd]'
+          // `hover:bg-white/10` is not decoration, it is the fix: the `outline`
+          // variant ships `hover:bg-accent hover:text-accent-foreground`, and
+          // `--accent` *is* this cyan. The `hover:text-[#00edfd]` beside it
+          // beats `accent-foreground`, so without a background of our own the
+          // label turned cyan on cyan and vanished under the cursor. Restating
+          // the background keeps the subtle-outline treatment that was meant.
+          className='h-8 gap-1.5 border-white/10 bg-white/5 px-2 text-xs text-white/70 hover:border-[#00edfd]/50 hover:bg-white/10 hover:text-[#00edfd]'
           onClick={() => onViewTeam(result)}
         >
           <Eye className='h-3.5 w-3.5' />

--- a/src/interfaces/premier-league.ts
+++ b/src/interfaces/premier-league.ts
@@ -1,0 +1,206 @@
+import type { TeamCode } from './fpl';
+
+/**
+ * The real Premier League: the table, the fixtures, the results.
+ *
+ * These come from a third upstream — the Pulse API behind premierleague.com —
+ * and not from either FPL game. See `agents/API.md` for why: the classic
+ * bootstrap carries `played`/`win`/`points` fields on every club and leaves
+ * them all at zero, so FPL cannot answer "what is the actual table?" at all.
+ *
+ * **Pulse types stay in this file and never mix with the FPL ones.** Pulse
+ * mints its own club ids (`club.id`: Arsenal is 1, Bournemouth 127) which are a
+ * *fourth* integer family alongside `LeagueEntryId`, `EntryId` and `ElementId`,
+ * and they overlap all three. Nothing below is branded and nothing below leaves
+ * the mapping layer: `toLeagueTableRow` and `toFixture` in
+ * `src/utils/premier-league.ts` convert every `Pulse*` shape into the view
+ * models at the bottom of this file, which key on {@link TeamCode} like the
+ * rest of the app. If a `Pulse*` type is imported by a component, that is the
+ * bug.
+ */
+
+/* ------------------------------------------------------------------ *
+ * Upstream shapes — exactly what Pulse returns, nothing tidied.
+ * ------------------------------------------------------------------ */
+
+/** A club, as Pulse describes it. `altIds.opta` is `"t" + our `TeamCode``. */
+export interface PulseTeam {
+  name: string;
+  shortName: string;
+  id: number;
+  club: { name: string; shortName: string; abbr: string; id: number };
+  altIds: { opta: string };
+}
+
+/** One row of the table. `detail=2` is what fills `form` and `annotations`. */
+export interface PulseStandingsEntry {
+  team: PulseTeam;
+  position: number;
+  /**
+   * Where the club started the current gameweek. Absent pre-season, which is
+   * one of the two signals that no football has been played yet.
+   */
+  startingPosition?: number;
+  overall: PulseTotals;
+  home: PulseTotals;
+  away: PulseTotals;
+  /** The last five fixtures, newest last. Empty before a ball is kicked. */
+  form: PulseFixture[];
+  /** Qualification and relegation markers: `EU_CL`, `EU_EL`, `RELEGATED`. */
+  annotations?: { type: string; destination?: string }[];
+}
+
+export interface PulseTotals {
+  played: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  goalsDifference: number;
+  points: number;
+}
+
+export interface PulseStandingsResponse {
+  compSeason: { id: number; label: string };
+  tables: {
+    /**
+     * **The pre-season tell, and the only reliable one.** Out of season Pulse
+     * returns all 20 clubs with every total at zero rather than an empty
+     * array, so a length check says "we have a table" about a page of noughts.
+     * `gameWeek` is `0` until the first match is played.
+     */
+    gameWeek: number;
+    entries: PulseStandingsEntry[];
+  }[];
+}
+
+/**
+ * One fixture.
+ *
+ * `teams` is always `[home, away]` — Pulse encodes the venue by position, not
+ * by a field, so nothing may sort or filter this array in place.
+ */
+export interface PulseFixture {
+  id: number;
+  /** `U` upcoming, `L` live, `C` complete. */
+  status: 'U' | 'L' | 'C';
+  /** Who won, once there is an answer. `H` home, `A` away, `D` draw. */
+  outcome?: 'H' | 'A' | 'D';
+  gameweek: { gameweek: number; compSeason: { id: number } };
+  kickoff: { millis?: number; label?: string; gmtOffset?: number };
+  teams: { team: PulseTeam; score?: number }[];
+  ground?: { name: string; city: string };
+  /** Minutes played, for a live match: `{ label: "74'00" }`. */
+  clock?: { secs: number; label: string };
+  altIds: { opta: string };
+}
+
+export interface PulseFixturesResponse {
+  pageInfo: { page: number; numPages: number; numEntries: number };
+  content: PulseFixture[];
+}
+
+export interface PulseCompSeasonsResponse {
+  content: { id: number; label: string }[];
+}
+
+/* ------------------------------------------------------------------ *
+ * View models — what the rest of the app is allowed to see.
+ * ------------------------------------------------------------------ */
+
+/** How a club finished one of its last five: newest last. */
+export type FormResult = 'W' | 'D' | 'L';
+
+/** A club, reduced to what a table row or a fixture card renders. */
+export interface PlClub {
+  /**
+   * The season-stable code {@link clubCrestUrl} takes, recovered from Pulse's
+   * `altIds.opta` (`"t3"` → `3`). Verified to match FPL's `teams[].code` for
+   * all 20 clubs, which is why this page needs no FPL call and no lookup
+   * table.
+   */
+  code: TeamCode;
+  name: string;
+  /** `"Bournemouth"`, where `name` is `"Bournemouth"` and abbr is `"BOU"`. */
+  shortName: string;
+  abbr: string;
+}
+
+export interface LeagueTableRow {
+  position: number;
+  club: PlClub;
+  played: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  goalDifference: number;
+  points: number;
+  /** Oldest first, at most five. Empty until the club has played. */
+  form: FormResult[];
+  /**
+   * Places gained since the gameweek began: positive is upward movement.
+   * `null` when Pulse gives no `startingPosition`, which is every row
+   * pre-season.
+   */
+  movement: number | null;
+  /** `EU_CL`, `EU_EL`, `EU_UECL`, `RELEGATED` — whatever Pulse marks. */
+  annotations: string[];
+}
+
+export interface PlFixture {
+  id: number;
+  gameweek: number;
+  status: 'U' | 'L' | 'C';
+  home: PlClub;
+  away: PlClub;
+  /** `null` until the match starts. Both or neither. */
+  homeScore: number | null;
+  awayScore: number | null;
+  outcome: 'H' | 'A' | 'D' | null;
+  /** Epoch milliseconds. `null` for a fixture with no date set yet. */
+  kickoffMillis: number | null;
+  /** Pulse's own pre-formatted string, e.g. `"Sat 22 Aug 2026, 12:30 BST"`. */
+  kickoffLabel: string | null;
+  ground: string | null;
+  /** Only ever set while `status` is `L`: `"74'00"`. */
+  clockLabel: string | null;
+}
+
+/** Every fixture of one gameweek, in kick-off order. */
+export interface GameweekFixtures {
+  gameweek: number;
+  fixtures: PlFixture[];
+}
+
+/**
+ * Everything the Premier League page renders, read once on the server.
+ *
+ * `hasStarted` is computed rather than inferred at the call site, because the
+ * two ways of getting it wrong — a truthy check on `entries`, or trusting a row
+ * of zeros — are the exact mistakes `agents/AGENTS.md` calls out.
+ */
+export interface PremierLeagueData {
+  /**
+   * `false` before the first match of the season.
+   *
+   * Nothing renders it today — the pre-season notice it was added for was
+   * dropped, because a table of noughts in August reads as early rather than
+   * broken. It stays because it is the one correct answer to "has football
+   * been played?", and the wrong ways to ask are the exact traps in
+   * `agents/AGENTS.md`. Anything tempted to check `table.length` or a club's
+   * `played` should read this instead.
+   */
+  hasStarted: boolean;
+  /**
+   * All 20 clubs, in Pulse's order. Pre-season that is every club on zero
+   * points, alphabetically, which is exactly what premierleague.com shows.
+   */
+  table: LeagueTableRow[];
+  /** All 38 gameweeks, ascending. */
+  gameweeks: GameweekFixtures[];
+  /** The gameweek a visitor should land on: live, else next up, else the last. */
+  currentGameweek: number;
+}

--- a/src/utils/fpl-api.ts
+++ b/src/utils/fpl-api.ts
@@ -16,6 +16,23 @@ const DRAFT_API = 'https://draft.premierleague.com/api';
 /** Classic FPL API. Powers the static dataset (teams, elements) and fixtures. */
 const FANTASY_API = 'https://fantasy.premierleague.com/api';
 
+/**
+ * The Pulse API behind premierleague.com. The real league table and the real
+ * fixture list — neither of which either FPL game can answer.
+ *
+ * It is here rather than in a module of its own because this file's job is to
+ * be the *one* place an upstream URL is written, and "upstream" is a boundary,
+ * not a vendor. Its own quirks are documented on the builders below.
+ */
+const PULSE_API = 'https://footballapi.pulselive.com/football';
+
+/**
+ * Pulse rejects a request with no `Origin` it recognises. Nothing else is
+ * needed — no key, no cookie — and the header is only meaningful server-side,
+ * which this module already is.
+ */
+const PULSE_HEADERS = { Origin: 'https://www.premierleague.com' } as const;
+
 const LEAGUE_ID_VAR = 'FPL_LEAGUE_ID';
 
 /**
@@ -58,14 +75,32 @@ export function getLeagueId(): number {
 export async function fetchUpstream<T>(
   url: string,
   revalidateSeconds: number,
+  headers?: Record<string, string>,
 ): Promise<T> {
-  const res = await fetch(url, { next: { revalidate: revalidateSeconds } });
+  const res = await fetch(url, {
+    headers,
+    next: { revalidate: revalidateSeconds },
+  });
 
   if (!res.ok) {
     throw new Error(`Request to ${url} failed with ${res.status}`);
   }
 
   return (await res.json()) as T;
+}
+
+/**
+ * The same read, with the `Origin` Pulse insists on.
+ *
+ * A separate function rather than a header argument at each call site, because
+ * a Pulse call that forgets the header does not fail loudly — it comes back
+ * `403` and reads as "the Premier League page is down".
+ */
+export async function fetchPulse<T>(
+  url: string,
+  revalidateSeconds: number,
+): Promise<T> {
+  return fetchUpstream<T>(url, revalidateSeconds, { ...PULSE_HEADERS });
 }
 
 export const fplApi = {
@@ -136,4 +171,43 @@ export const fplApi = {
    * The trailing slash is required — without it the API answers 301.
    */
   fixtures: () => `${FANTASY_API}/fixtures/`,
+} as const;
+
+/**
+ * The Pulse API — the real Premier League, as premierleague.com renders it.
+ *
+ * Every one of these needs the `Origin` header: go through `fetchPulse`.
+ *
+ * **`compSeasonId` is season-scoped, exactly like the draft league ID**, so it
+ * is never written down. `pulseApi.compSeasons()` lists them and
+ * `getCompSeasonId()` in `premier-league-data.ts` picks the newest. Do not be
+ * tempted to parse the labels to find it: they are not one format. The current
+ * season reads `"English Premier League Season 2026/2027"` while the one before
+ * it reads `"2025/26"`.
+ */
+export const pulseApi = {
+  /**
+   * Every Premier League season Pulse knows, newest first, as `{ id, label }`.
+   * Competition `1` is the Premier League.
+   */
+  compSeasons: () => `${PULSE_API}/competitions/1/compseasons?pageSize=50`,
+
+  /**
+   * The league table. `detail=2` is what adds `form`, `annotations` and the
+   * home/away splits; without it you get positions and totals only.
+   *
+   * Out of season this returns all 20 clubs on zero with `tables[0].gameWeek`
+   * of `0` — **not** an empty array. Guard on `gameWeek`, never on length.
+   */
+  standings: (compSeasonId: number) =>
+    `${PULSE_API}/standings?compSeasons=${compSeasonId}&altIds=true&detail=2`,
+
+  /**
+   * All 380 fixtures in one response — `pageSize` of 400 returns `numPages: 1`,
+   * so this never needs paging. `statuses=U,L,C` asks for upcoming, live and
+   * complete, which is everything.
+   */
+  fixtures: (compSeasonId: number) =>
+    `${PULSE_API}/fixtures?comps=1&compSeasons=${compSeasonId}` +
+    '&pageSize=400&page=0&sort=asc&statuses=U,L,C&altIds=true',
 } as const;

--- a/src/utils/premier-league-data.ts
+++ b/src/utils/premier-league-data.ts
@@ -1,0 +1,125 @@
+import 'server-only';
+
+import { fetchPulse, pulseApi } from '@/utils/fpl-api';
+import type {
+  GameweekFixtures,
+  LeagueTableRow,
+  PlFixture,
+  PremierLeagueData,
+  PulseCompSeasonsResponse,
+  PulseFixturesResponse,
+  PulseStandingsResponse,
+} from '@/interfaces/premier-league';
+import {
+  groupByGameweek,
+  hasSeasonStarted,
+  newestCompSeasonId,
+  pickCurrentGameweek,
+  toFixture,
+  toLeagueTable,
+} from '@/utils/premier-league';
+import { cachedRead } from './cache';
+
+/**
+ * The real Premier League table and fixture list, read on the server.
+ *
+ * The fetching, caching and season lookup half of the pair; every rule lives
+ * next door in `premier-league.ts`, which is pure and tested. Same split as
+ * `gameweek-data.ts` against `scoring.ts`, for the same reason: a rule inside
+ * an `async` function wrapped around three upstream calls cannot be tested.
+ *
+ * **There is deliberately no fallback.** The old FPL-derived table was
+ * considered and rejected: it cannot see points deductions, so it would differ
+ * from the official table by a few points in exactly the season where that
+ * matters, and it would do it silently. If Pulse is unreachable the page says
+ * the Premier League could not be reached. A wrong table is worse than no
+ * table.
+ */
+
+const SEASON_KEY = 'pulse-compseason';
+const SEASON_TTL_SECONDS = 86_400; // a day — a season ID changes once, in June
+
+const DATA_KEY = 'premier-league';
+/**
+ * Five minutes. Long enough that a busy Saturday does not re-fetch per
+ * visitor, short enough that a live score is never stale enough to argue with
+ * the television.
+ */
+const DATA_TTL_SECONDS = 300;
+
+/**
+ * The current season's Pulse ID.
+ *
+ * Discovered, never written down — it is a season-scoped identifier exactly
+ * like `FPL_LEAGUE_ID`, and hard-coding one is what the house rules forbid.
+ * Cached for a day on its own key rather than folded into the read below, so
+ * the five-minute score refresh does not re-ask a question whose answer
+ * changes annually.
+ */
+const getCompSeasonId = cachedRead(
+  SEASON_KEY,
+  SEASON_TTL_SECONDS,
+  async (): Promise<number> => {
+    const response = await fetchPulse<PulseCompSeasonsResponse>(
+      pulseApi.compSeasons(),
+      SEASON_TTL_SECONDS,
+    );
+
+    const id = newestCompSeasonId(response);
+
+    if (id === null) {
+      throw new Error('Pulse listed no Premier League seasons.');
+    }
+
+    return id;
+  },
+);
+
+/** The table and every fixture, cached. The page calls this and nothing else. */
+export async function getPremierLeagueData(): Promise<PremierLeagueData> {
+  const { hasStarted, table, gameweeks } = await readSeason();
+
+  return {
+    hasStarted,
+    table,
+    gameweeks,
+    // Computed per request rather than inside the cache: which gameweek is
+    // "current" is a function of the clock, and a cached answer would keep
+    // pointing at last weekend for the whole TTL.
+    currentGameweek: pickCurrentGameweek(gameweeks, Date.now()),
+  };
+}
+
+const readSeason = cachedRead(
+  DATA_KEY,
+  DATA_TTL_SECONDS,
+  async (): Promise<Omit<PremierLeagueData, 'currentGameweek'>> => {
+    const compSeasonId = await getCompSeasonId();
+
+    // Two independent reads of the same season — no reason to serialise them.
+    const [standings, fixtures] = await Promise.all([
+      fetchPulse<PulseStandingsResponse>(
+        pulseApi.standings(compSeasonId),
+        DATA_TTL_SECONDS,
+      ),
+      fetchPulse<PulseFixturesResponse>(
+        pulseApi.fixtures(compSeasonId),
+        DATA_TTL_SECONDS,
+      ),
+    ]);
+
+    const table: LeagueTableRow[] = toLeagueTable(standings);
+
+    const mapped = (fixtures.content ?? [])
+      .map(toFixture)
+      .filter((fixture): fixture is PlFixture => fixture !== null);
+
+    const gameweeks: GameweekFixtures[] = groupByGameweek(mapped);
+
+    return {
+      hasStarted: hasSeasonStarted(standings),
+      table,
+      gameweeks,
+    };
+  },
+);

--- a/src/utils/premier-league.test.ts
+++ b/src/utils/premier-league.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  PulseFixture,
+  PulseStandingsEntry,
+  PulseStandingsResponse,
+  PulseTeam,
+} from '@/interfaces/premier-league';
+import {
+  formFrom,
+  groupByGameweek,
+  hasSeasonStarted,
+  newestCompSeasonId,
+  optaTeamCode,
+  pickCurrentGameweek,
+  toClub,
+  toFixture,
+  toLeagueTableRow,
+} from './premier-league';
+
+function team(id: number, opta: string, name = `Club ${id}`): PulseTeam {
+  return {
+    name,
+    shortName: name,
+    id,
+    club: { name, shortName: name, abbr: name.slice(0, 3).toUpperCase(), id },
+    altIds: { opta },
+  };
+}
+
+function fixture(overrides: Partial<PulseFixture> = {}): PulseFixture {
+  return {
+    id: 1,
+    status: 'C',
+    gameweek: { gameweek: 1, compSeason: { id: 841 } },
+    kickoff: { millis: 1_000 },
+    teams: [
+      { team: team(1, 't3'), score: 2 },
+      { team: team(2, 't7'), score: 0 },
+    ],
+    altIds: { opta: 'g1' },
+    ...overrides,
+  };
+}
+
+function entry(overrides: Partial<PulseStandingsEntry> = {}) {
+  return {
+    team: team(1, 't3', 'Arsenal'),
+    position: 1,
+    overall: {
+      played: 1,
+      won: 1,
+      drawn: 0,
+      lost: 0,
+      goalsFor: 2,
+      goalsAgainst: 0,
+      goalsDifference: 2,
+      points: 3,
+    },
+    home: {
+      played: 1,
+      won: 1,
+      drawn: 0,
+      lost: 0,
+      goalsFor: 2,
+      goalsAgainst: 0,
+      goalsDifference: 2,
+      points: 3,
+    },
+    away: {
+      played: 0,
+      won: 0,
+      drawn: 0,
+      lost: 0,
+      goalsFor: 0,
+      goalsAgainst: 0,
+      goalsDifference: 0,
+      points: 0,
+    },
+    form: [],
+    ...overrides,
+  } satisfies PulseStandingsEntry;
+}
+
+describe('optaTeamCode', () => {
+  it('recovers the crest code from a Pulse alt-ID', () => {
+    // Verified against all 20 clubs: Pulse's opta alt-ID is `t` plus exactly
+    // the `teams[].code` FPL uses, which is what `clubCrestUrl` takes.
+    expect(optaTeamCode('t3')).toBe(3);
+    expect(optaTeamCode('t91')).toBe(91);
+  });
+
+  it('rejects anything that is not that shape', () => {
+    for (const bad of ['', 'p123', '3', 't', 'tt3', 't3x', undefined]) {
+      expect(optaTeamCode(bad)).toBeNull();
+    }
+  });
+});
+
+describe('toClub', () => {
+  it('drops a club it cannot map rather than inventing a code', () => {
+    // The only consumer of `code` is a crest URL, and the asset host answers a
+    // wrong code with 403 — a broken image and nothing in the log.
+    expect(toClub({ ...team(1, 'nonsense') })).toBeNull();
+    expect(toClub(undefined)).toBeNull();
+  });
+
+  it('keeps the club name over the team name', () => {
+    expect(toClub(team(10, 't14', 'Liverpool'))?.name).toBe('Liverpool');
+    expect(toClub(team(10, 't14'))?.code).toBe(14);
+  });
+});
+
+describe('hasSeasonStarted', () => {
+  const twentyClubsOnZero: PulseStandingsResponse = {
+    compSeason: { id: 841, label: 'English Premier League Season 2026/2027' },
+    tables: [
+      { gameWeek: 0, entries: Array.from({ length: 20 }, () => entry()) },
+    ],
+  };
+
+  it('is false pre-season, when upstream still returns a full table', () => {
+    // The trap this exists for: `entries.length` is 20 in August. A truthy or
+    // length check answers "we have a table" about a page of noughts.
+    expect(twentyClubsOnZero.tables[0].entries).toHaveLength(20);
+    expect(hasSeasonStarted(twentyClubsOnZero)).toBe(false);
+  });
+
+  it('is true once a gameweek has been played', () => {
+    expect(
+      hasSeasonStarted({
+        ...twentyClubsOnZero,
+        tables: [{ ...twentyClubsOnZero.tables[0], gameWeek: 1 }],
+      }),
+    ).toBe(true);
+  });
+
+  it('is false for a response with no tables at all', () => {
+    expect(
+      hasSeasonStarted({ compSeason: { id: 1, label: '' }, tables: [] }),
+    ).toBe(false);
+  });
+});
+
+describe('formFrom', () => {
+  it('reads a win from the side the club was on, not from the outcome', () => {
+    const home = formFrom(
+      entry({
+        form: [fixture({ outcome: 'H' })],
+      }),
+    );
+    expect(home).toEqual(['W']);
+
+    // Same fixture, same `outcome: 'H'` — but this club was the away side.
+    const away = formFrom(
+      entry({
+        team: team(2, 't7'),
+        form: [fixture({ outcome: 'H' })],
+      }),
+    );
+    expect(away).toEqual(['L']);
+  });
+
+  it('orders oldest first regardless of how upstream sent them', () => {
+    expect(
+      formFrom(
+        entry({
+          form: [
+            fixture({ id: 2, outcome: 'D', kickoff: { millis: 5_000 } }),
+            fixture({ id: 1, outcome: 'H', kickoff: { millis: 1_000 } }),
+          ],
+        }),
+      ),
+    ).toEqual(['W', 'D']);
+  });
+
+  it('ignores a fixture with no outcome or one the club is not in', () => {
+    expect(
+      formFrom(
+        entry({
+          form: [
+            fixture({ outcome: undefined }),
+            fixture({
+              outcome: 'H',
+              teams: [{ team: team(8, 't11') }, { team: team(9, 't31') }],
+            }),
+          ],
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('toLeagueTableRow', () => {
+  it('reads movement as places gained, so a rise is positive', () => {
+    // Position 3 having started the gameweek 1st is a fall of two.
+    expect(
+      toLeagueTableRow(entry({ position: 3, startingPosition: 1 }))?.movement,
+    ).toBe(-2);
+    expect(
+      toLeagueTableRow(entry({ position: 1, startingPosition: 4 }))?.movement,
+    ).toBe(3);
+  });
+
+  it('leaves movement null pre-season rather than claiming zero', () => {
+    expect(toLeagueTableRow(entry())?.movement).toBeNull();
+  });
+});
+
+describe('toFixture', () => {
+  it('keeps a nil-nil as a played result, not as unplayed', () => {
+    // `0` is a real score. A truthiness check here would render a completed
+    // goalless draw as a fixture yet to kick off.
+    const goalless = toFixture(
+      fixture({
+        outcome: 'D',
+        teams: [
+          { team: team(1, 't3'), score: 0 },
+          { team: team(2, 't7'), score: 0 },
+        ],
+      }),
+    );
+
+    expect(goalless?.homeScore).toBe(0);
+    expect(goalless?.awayScore).toBe(0);
+  });
+
+  it('leaves both scores null for an upcoming fixture', () => {
+    const upcoming = toFixture(
+      fixture({
+        status: 'U',
+        outcome: undefined,
+        teams: [{ team: team(1, 't3') }, { team: team(2, 't7') }],
+      }),
+    );
+
+    expect(upcoming?.homeScore).toBeNull();
+    expect(upcoming?.awayScore).toBeNull();
+  });
+
+  it('shows a clock only while a match is live', () => {
+    const clock = { secs: 5_700, label: "90+5'00" };
+
+    expect(toFixture(fixture({ status: 'L', clock }))?.clockLabel).toBe(
+      "90+5'00",
+    );
+    // A completed match still carries `90+5'00`, which as a badge reads as
+    // in-progress.
+    expect(toFixture(fixture({ status: 'C', clock }))?.clockLabel).toBeNull();
+  });
+
+  it('drops a fixture whose clubs cannot be mapped', () => {
+    expect(
+      toFixture(
+        fixture({
+          teams: [{ team: team(1, 'bad') }, { team: team(2, 't7') }],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('treats teams as [home, away] by position', () => {
+    const mapped = toFixture(fixture());
+
+    expect(mapped?.home.code).toBe(3);
+    expect(mapped?.away.code).toBe(7);
+  });
+});
+
+describe('groupByGameweek', () => {
+  const mapped = [
+    fixture({ id: 3, gameweek: { gameweek: 2, compSeason: { id: 1 } } }),
+    fixture({
+      id: 2,
+      gameweek: { gameweek: 1, compSeason: { id: 1 } },
+      kickoff: { millis: 9_000 },
+    }),
+    fixture({
+      id: 1,
+      gameweek: { gameweek: 1, compSeason: { id: 1 } },
+      kickoff: { millis: 2_000 },
+    }),
+  ]
+    .map(toFixture)
+    .flatMap((f) => (f ? [f] : []));
+
+  it('orders gameweeks, and fixtures by kick-off within them', () => {
+    const grouped = groupByGameweek(mapped);
+
+    expect(grouped.map((week) => week.gameweek)).toEqual([1, 2]);
+    expect(grouped[0].fixtures.map((f) => f.id)).toEqual([1, 2]);
+  });
+
+  it('drops an unscheduled fixture rather than inventing gameweek 0', () => {
+    const orphan = toFixture(
+      fixture({ id: 9, gameweek: { gameweek: 0, compSeason: { id: 1 } } }),
+    );
+
+    expect(groupByGameweek([...mapped, orphan!])).toHaveLength(2);
+  });
+});
+
+describe('pickCurrentGameweek', () => {
+  const week = (gameweek: number, fixtures: Partial<PulseFixture>[]) => ({
+    gameweek,
+    fixtures: fixtures
+      .map((f) =>
+        toFixture(
+          fixture({ ...f, gameweek: { gameweek, compSeason: { id: 1 } } }),
+        ),
+      )
+      .flatMap((f) => (f ? [f] : [])),
+  });
+
+  it('prefers a gameweek with a match in progress', () => {
+    const weeks = [
+      week(1, [{ status: 'C' }]),
+      week(2, [{ status: 'L' }]),
+      week(3, [{ status: 'U', kickoff: { millis: 100 } }]),
+    ];
+
+    expect(pickCurrentGameweek(weeks, 50)).toBe(2);
+  });
+
+  it('otherwise lands on the next round still to be played', () => {
+    // The Tuesday case: last weekend is done, and the useful tab is what is
+    // coming rather than gameweek 1.
+    const weeks = [
+      week(1, [{ status: 'C' }]),
+      week(2, [{ status: 'C' }]),
+      week(3, [{ status: 'U', kickoff: { millis: 9_000 } }]),
+    ];
+
+    expect(pickCurrentGameweek(weeks, 5_000)).toBe(3);
+  });
+
+  it('falls back to the last gameweek once the season is over', () => {
+    const weeks = [week(37, [{ status: 'C' }]), week(38, [{ status: 'C' }])];
+
+    expect(pickCurrentGameweek(weeks, 10_000)).toBe(38);
+  });
+
+  it('does not throw on an empty season', () => {
+    expect(pickCurrentGameweek([], 0)).toBe(1);
+  });
+});
+
+describe('newestCompSeasonId', () => {
+  it('picks by ID, never by parsing the label', () => {
+    // Pulse's labels are not one format. These two are real, and adjacent.
+    expect(
+      newestCompSeasonId({
+        content: [
+          { id: 841, label: 'English Premier League Season 2026/2027' },
+          { id: 777, label: '2025/26' },
+          { id: 719, label: '2024/25' },
+        ],
+      }),
+    ).toBe(841);
+  });
+
+  it('is null when Pulse lists nothing', () => {
+    expect(newestCompSeasonId({ content: [] })).toBeNull();
+  });
+});

--- a/src/utils/premier-league.ts
+++ b/src/utils/premier-league.ts
@@ -1,0 +1,267 @@
+import { asTeamCode } from '@/interfaces/fpl';
+import type {
+  FormResult,
+  GameweekFixtures,
+  LeagueTableRow,
+  PlClub,
+  PlFixture,
+  PulseCompSeasonsResponse,
+  PulseFixture,
+  PulseStandingsEntry,
+  PulseStandingsResponse,
+  PulseTeam,
+} from '@/interfaces/premier-league';
+
+/**
+ * Turning Pulse payloads into the app's view models. Pure, and tested.
+ *
+ * The split mirrors `scoring.ts` against `gameweek-data.ts`: everything here
+ * is a function of its arguments, so every rule below is pinned by a test in
+ * `premier-league.test.ts`. `premier-league-data.ts` keeps the fetching, the
+ * caching and the season lookup and calls into this module.
+ *
+ * The rules worth knowing before you change anything:
+ *
+ * - **A club we cannot map is dropped, never faked.** `toClub` returns `null`
+ *   rather than a placeholder, because the only thing downstream of a club is
+ *   a crest URL and the asset host answers a wrong code with `403` — a broken
+ *   image and nothing in the log.
+ * - **Pre-season is a state, not an absence.** Pulse hands back 20 clubs on
+ *   zero points rather than an empty list, so anything asking "has football
+ *   been played?" must go through `hasSeasonStarted`, which reads `gameWeek`.
+ *   A length check on `entries` is true in August and answers a different
+ *   question.
+ * - **`teams` is `[home, away]` by position.** Nothing here sorts it.
+ */
+
+/** `"t91"` → `91`, the code `clubCrestUrl` wants. `null` if it is not that. */
+export function optaTeamCode(optaId: string | undefined): number | null {
+  if (!optaId) return null;
+
+  const match = /^t(\d+)$/.exec(optaId);
+
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * A Pulse club, reduced to what we render.
+ *
+ * `null` when the opta alt-ID is missing or malformed — which means the caller
+ * omits the row or the fixture entirely. That is the right failure: a table
+ * missing a club is visibly wrong, where a table with a blank crest and the
+ * name "Unknown" looks like a rendering nit and gets ignored.
+ */
+export function toClub(team: PulseTeam | undefined): PlClub | null {
+  const code = optaTeamCode(team?.altIds?.opta);
+
+  if (!team || code === null) return null;
+
+  return {
+    code: asTeamCode(code),
+    name: team.club?.name ?? team.name,
+    shortName: team.club?.shortName ?? team.shortName ?? team.name,
+    abbr: team.club?.abbr ?? '',
+  };
+}
+
+/**
+ * How one club fared in the five fixtures Pulse attaches to its table row.
+ *
+ * Derived rather than read: Pulse gives the fixtures, not the letters, and
+ * whether `outcome: 'H'` is a win depends on which side of `teams` the club
+ * was on. Sorted by kick-off rather than trusting the array's order, so the
+ * pills read oldest-to-newest whichever way upstream sends them.
+ */
+export function formFrom(entry: PulseStandingsEntry): FormResult[] {
+  const teamId = entry.team?.id;
+
+  return [...(entry.form ?? [])]
+    .sort((a, b) => (a.kickoff?.millis ?? 0) - (b.kickoff?.millis ?? 0))
+    .map((fixture): FormResult | null => {
+      if (!fixture.outcome) return null;
+      if (fixture.outcome === 'D') return 'D';
+
+      const wasHome = fixture.teams?.[0]?.team?.id === teamId;
+      const wasAway = fixture.teams?.[1]?.team?.id === teamId;
+
+      // A fixture the club does not appear in is upstream nonsense, not a loss.
+      if (!wasHome && !wasAway) return null;
+
+      const homeWon = fixture.outcome === 'H';
+
+      return wasHome === homeWon ? 'W' : 'L';
+    })
+    .filter((result): result is FormResult => result !== null);
+}
+
+/** One row of the table. `null` for a club that cannot be mapped. */
+export function toLeagueTableRow(
+  entry: PulseStandingsEntry,
+): LeagueTableRow | null {
+  const club = toClub(entry.team);
+
+  if (!club) return null;
+
+  const totals = entry.overall;
+
+  return {
+    position: entry.position,
+    club,
+    played: totals.played,
+    won: totals.won,
+    drawn: totals.drawn,
+    lost: totals.lost,
+    goalsFor: totals.goalsFor,
+    goalsAgainst: totals.goalsAgainst,
+    goalDifference: totals.goalsDifference,
+    points: totals.points,
+    form: formFrom(entry),
+    // Upward movement is a *fall* in position number, hence the subtraction
+    // this way round. Absent pre-season, when there is no previous position to
+    // have moved from — `null`, so the column renders nothing rather than a
+    // confident zero.
+    movement:
+      typeof entry.startingPosition === 'number'
+        ? entry.startingPosition - entry.position
+        : null,
+    annotations: (entry.annotations ?? []).map(
+      (note) => note.destination ?? note.type,
+    ),
+  };
+}
+
+/**
+ * Has a ball been kicked this season?
+ *
+ * `tables[0].gameWeek` is `0` until the first match, while `entries` is a full
+ * twenty clubs either way. This is the whole reason the check is a named
+ * function: `if (response.tables[0].entries.length)` is true in August and
+ * answers the wrong question.
+ */
+export function hasSeasonStarted(response: PulseStandingsResponse): boolean {
+  const table = response.tables?.[0];
+
+  return (table?.gameWeek ?? 0) > 0;
+}
+
+/** The table, ordered as Pulse ordered it. Unmappable clubs are dropped. */
+export function toLeagueTable(
+  response: PulseStandingsResponse,
+): LeagueTableRow[] {
+  return (response.tables?.[0]?.entries ?? [])
+    .map(toLeagueTableRow)
+    .filter((row): row is LeagueTableRow => row !== null);
+}
+
+/** One fixture. `null` if either club fails to map. */
+export function toFixture(fixture: PulseFixture): PlFixture | null {
+  const home = toClub(fixture.teams?.[0]?.team);
+  const away = toClub(fixture.teams?.[1]?.team);
+
+  if (!home || !away) return null;
+
+  const homeScore = fixture.teams[0]?.score;
+  const awayScore = fixture.teams[1]?.score;
+
+  // Scores arrive together or not at all, and `0` is a real score — so the
+  // test is for the number, never for truthiness.
+  const played = typeof homeScore === 'number' && typeof awayScore === 'number';
+
+  return {
+    id: fixture.id,
+    gameweek: fixture.gameweek?.gameweek ?? 0,
+    status: fixture.status,
+    home,
+    away,
+    homeScore: played ? homeScore : null,
+    awayScore: played ? awayScore : null,
+    outcome: fixture.outcome ?? null,
+    kickoffMillis: fixture.kickoff?.millis ?? null,
+    kickoffLabel: fixture.kickoff?.label ?? null,
+    ground: fixture.ground?.name ?? null,
+    // Only a live match has a meaningful clock. A completed one carries
+    // `90+5'00`, which as a badge on a finished result reads as in-progress.
+    clockLabel: fixture.status === 'L' ? (fixture.clock?.label ?? null) : null,
+  };
+}
+
+/**
+ * The 380 fixtures, split into gameweeks and sorted by kick-off within each.
+ *
+ * A fixture with no gameweek is dropped rather than collected under `0`: it is
+ * a postponement upstream has not re-scheduled, and a phantom "gameweek 0" tab
+ * is worse than its absence.
+ */
+export function groupByGameweek(fixtures: PlFixture[]): GameweekFixtures[] {
+  const byGameweek = new Map<number, PlFixture[]>();
+
+  for (const fixture of fixtures) {
+    if (fixture.gameweek < 1) continue;
+
+    const bucket = byGameweek.get(fixture.gameweek);
+
+    if (bucket) bucket.push(fixture);
+    else byGameweek.set(fixture.gameweek, [fixture]);
+  }
+
+  return [...byGameweek.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([gameweek, list]) => ({
+      gameweek,
+      fixtures: list.sort(
+        (a, b) => (a.kickoffMillis ?? 0) - (b.kickoffMillis ?? 0),
+      ),
+    }));
+}
+
+/**
+ * Which gameweek a visitor should land on.
+ *
+ * In order of preference: one with a match in progress, then the earliest with
+ * anything still to play, then the last of the season. The middle case is what
+ * makes the page useful on a Tuesday — the weekend's results have finished but
+ * the next round has not started, and the interesting tab is the one coming up
+ * rather than gameweek 1.
+ *
+ * Takes `now` as an argument rather than reading the clock, so the rule is
+ * testable. Every caller passes `Date.now()`.
+ */
+export function pickCurrentGameweek(
+  gameweeks: GameweekFixtures[],
+  now: number,
+): number {
+  if (gameweeks.length === 0) return 1;
+
+  const live = gameweeks.find((week) =>
+    week.fixtures.some((fixture) => fixture.status === 'L'),
+  );
+
+  if (live) return live.gameweek;
+
+  const upcoming = gameweeks.find((week) =>
+    week.fixtures.some(
+      (fixture) =>
+        fixture.status === 'U' && (fixture.kickoffMillis ?? Infinity) >= now,
+    ),
+  );
+
+  return upcoming?.gameweek ?? gameweeks[gameweeks.length - 1].gameweek;
+}
+
+/**
+ * The current season's Pulse ID: the highest one it lists.
+ *
+ * **By ID, not by label.** Pulse's own labels are inconsistent between seasons
+ * — `"English Premier League Season 2026/2027"` sits directly above
+ * `"2025/26"` in the same response — so any parse of them is a bug waiting for
+ * next August. IDs ascend, which is the only property this needs.
+ */
+export function newestCompSeasonId(
+  response: PulseCompSeasonsResponse,
+): number | null {
+  const ids = (response.content ?? [])
+    .map((season) => season.id)
+    .filter((id) => Number.isFinite(id));
+
+  return ids.length > 0 ? Math.max(...ids) : null;
+}


### PR DESCRIPTION
Adds `/premier-league` — the actual league table, and every fixture and result.

## Why a third upstream

Neither FPL game can answer "what is the table?". The classic bootstrap carries `played`, `win`, `draw`, `loss`, `points` and `position` on every club and leaves **every one of them at zero**. So this reads the Pulse API behind premierleague.com.

Deriving a table from finished fixtures was considered and rejected: it cannot see a points deduction, so it would disagree with the official table by a few points in exactly the season where that matters, and it would do it silently. **There is deliberately no fallback** — if Pulse is unreachable the page says so.

## The crest join is free

Pulse's `team.altIds.opta` is `"t"` plus **exactly** the `teams[].code` the classic bootstrap uses — verified across all 20 clubs (`ARS → t3`, `BOU → t91`, `BRE → t94`). Since `clubCrestUrl` builds `…/badges/t{code}.svg`, Pulse hands over the crest key directly.

So this page makes **no FPL call at all** and needs no club mapping table.

## Shape

- Pure transforms in `premier-league.ts`, fetching and caching in `premier-league-data.ts` — the same split as `scoring.ts` against `gameweek-data.ts`. **28 new tests** pin the rules.
- `compSeasons` is discovered by highest id, never hard-coded and never parsed from the label. Pulse's labels are not one format: `"English Premier League Season 2026/2027"` sits directly above `"2025/26"` in the same response.
- The table renders through `BaseTable`, the primitive the standings board uses, so both tables share a row height and hover shape.
- Fixtures and results are one tab, not two. A gameweek in progress is half played, and splitting it would put the same round in two places — the score column carries the state instead.

## Traps this had to handle

- **Pre-season Pulse returns all 20 clubs on zero, not an empty array.** `entries.length` is `20` in August, so a length check answers "we have a table" about a page of noughts. `hasSeasonStarted` reads `tables[0].gameWeek`.
- **`0` is a real score.** A truthiness check would render a completed goalless draw as a fixture yet to kick off.
- **Annotation codes are observed, not guessed.** Relegation is `EN_CH` (Pulse names the destination competition, the English Championship) and the Conference League is `EU_UC` — not the `RELEGATED`/`EU_UECL` their branding suggests. An unknown code renders no stripe rather than a wrong one.

## Three fixes found along the way

- **"View team" was illegible on hover.** The `outline` variant ships `hover:bg-accent`, and `--accent` is the same cyan as its `hover:text` — cyan on cyan.
- **Nav icons read as out of focus.** Two causes: `backdrop-filter` forced the bar's whole subtree onto one composited layer where five `flex-1` items land on fractional pixels, and the icons were dimmed to 40% white besides. New `glass-panel` utility paints the blur behind the panel; icons are solid white.
- **`GameweekSelector` never scrolled its selection into view**, so a strip opening past the first few gameweeks looked like it had lost the selection. Also affects `/results` and `/rumblers`.

## Verification

`lint` (0 errors, 2 pre-existing warnings), `typecheck`, `test` (104 passing), `format:check` and `build` all green.

Beyond that, the transforms were run against **real 2024/25 Pulse payloads**: 20 clubs mapped, all 380 fixtures across 38 gameweeks, and W+D+L reconciling against played on every row. That is what caught the wrong annotation codes.

## Not verified

- **Whether Pulse serves Vercel's egress IPs.** Works locally. This is the only way the feature fails in production while passing everywhere else — if the deployed page 403s, that is the cause, not the header. Noted in API.md.
- **Nothing has run against a live season.** First real exercise is 21 August.

🤖 Generated with [Claude Code](https://claude.com/claude-code)