### PR TITLE
docs: compound the learnings from #15-#20 into agents/

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -54,8 +54,9 @@ Vercel agree on the runtime. Change one and change the other.
 
 ## The core boundary: upstream API access is server-only, always
 
-**Rule: the browser never calls `draft.premierleague.com` or `fantasy.premierleague.com`
-directly.** All upstream access flows through server-only modules.
+**Rule: the browser never calls `draft.premierleague.com`, `fantasy.premierleague.com` or
+`footballapi.pulselive.com` directly.** All upstream access flows through server-only
+modules.
 
 ```
   app/**/page.tsx                ── async Server Component: reads its own data
@@ -63,12 +64,14 @@ directly.** All upstream access flows through server-only modules.
      │                              client components are leaves, for interaction only
      ▼
   src/utils/gameweek-data.ts     ── the data layer: fetch, score, rank, aggregate
+  src/utils/premier-league-data.ts  the Pulse table + fixtures
      │                              (in-memory TTL cache + promise dedup)
      ▼
   src/utils/fpl-api.ts           ── `import 'server-only'`
      │                              the ONLY place upstream URLs and FPL_LEAGUE_ID live
+     │                              `fplApi` for the two FPL games, `pulseApi` for Pulse
      ▼
-  draft.premierleague.com  /  fantasy.premierleague.com
+  draft.premierleague.com · fantasy.premierleague.com · footballapi.pulselive.com
 ```
 
 **Pages read their own data.** There is no client-fetch layer any more: no `apiHelper`, no
@@ -208,6 +211,12 @@ specific behaviours have already caused real bugs in this repo:
 - **`league_entries[].id` and `league_entries[].entry_id` are different numbers.** `id` is
   the league entry (what we use as the player ID everywhere); `entry_id` goes in
   `/api/entry/...` URLs.
+- **Pre-season Pulse returns all 20 clubs on zero, not an empty array.** `entries.length` is
+  `20` in August, so a length check answers "we have a table" about a page of noughts. Read
+  `tables[0].gameWeek` instead.
+- **Pulse's season list must be picked by highest `id`, never by parsing the label.** Its
+  labels are not one format: `"English Premier League Season 2026/2027"` sits directly above
+  `"2025/26"` in the same response.
 
 All of it, with observed payloads, is in [API.md](./API.md). When you add an endpoint,
 document it there in the same change.
@@ -241,6 +250,10 @@ Upstream returns `{}` and `[]` for "nothing yet" and 404s for "not applicable", 
 same season. Check `Object.keys(x).length` / `x.length`, never `if (x)`. A gameweek with no
 data must be **absent** from the results, never scored as zeros — zeros rank, and ranking
 awards points.
+
+**And `0` is a real value, not "not yet".** Test `typeof score === 'number'`, never
+truthiness, or a completed goalless draw renders as a fixture still to kick off. Any field
+where "none" and "not known yet" are both plausible needs the same care.
 
 ---
 
@@ -355,6 +368,36 @@ awards points.
   `pnpm dlx shadcn@latest add <component>` — `components.json` is already pointed at
   `src/app/globals.css` with no config file, which is the v4 layout.
 
+### Never assemble a Tailwind class name at runtime
+
+**Tailwind scans source text.** A class built from a variable is a string it has never seen,
+so it generates no rule for it — and nothing fails. Not the build, not the typecheck, not
+lint.
+
+```ts
+// ✗ compiles, typechecks, and silently produces no CSS
+return `hidden ${hideBelow}:table-cell`;
+
+// ✓ every class spelled out where the scanner can read it
+const HIDDEN_BELOW = {
+  sm: 'hidden sm:table-cell',
+  md: 'hidden md:table-cell',
+  lg: 'hidden lg:table-cell',
+} as const;
+```
+
+This shipped. `hiddenClasses` in `base-table.tsx` built its class that way, so the
+stylesheet held `.md\:table-cell` and nothing else — `md` survived only because
+`table-skeleton.tsx` happens to spell that string out literally. Every column marked `sm` or
+`lg` kept its `hidden` and never got `table-cell` back: **invisible at every width** rather
+than hidden below one. On the league table that meant Form and W/D/L never appeared at all.
+
+The failure mode is what makes this a law. A missing column reads as a design decision, not
+a bug, so it survives review — it took someone asking where the form column had gone. Any
+variable that picks a class picks a **whole class** from a literal lookup;
+`HIDDEN_BELOW` in `base-table.tsx` and `COLUMNS` in `SectionTabs` are both that shape. The
+same applies to a colour ramp, a grid width, or a breakpoint chosen by data.
+
 ---
 
 ## Language and voice
@@ -386,19 +429,41 @@ awards points.
 **Vitest, colocated `*.test.ts`, run with `pnpm test`.** Config is `vitest.config.mts` — the
 `@/` alias has to be repeated there, because Vitest does not read `tsconfig.json` paths.
 
-**Test the scoring layer, not the fetching.** Everything worth testing here is pure, and it
-lives in [`src/utils/scoring.ts`](../src/utils/scoring.ts): `assignRanks`, `scoreGameweek`,
-`aggregatePlayers`, `buildRumblerData`. `gameweek-data.ts` keeps the fetch, the database and
-the cache, and calls into that module. **Keep that split.** A rule that only exists inside
-an `async` function wrapped around 344 upstream calls cannot be tested, and every rule in
-here has already been broken once in production:
+**Test the rules, not the fetching.** The split is always the same pair: a pure module holds
+every rule, and an `async` sibling holds the fetch, the database and the cache and calls
+into it.
+
+| Pure (tested)          | Impure sibling           | What the rules decide                      |
+| ---------------------- | ------------------------ | ------------------------------------------ |
+| `scoring.ts`           | `gameweek-data.ts`       | ranks, F1 points, rumblers, aggregation    |
+| `premier-league.ts`    | `premier-league-data.ts` | Pulse payload → table, fixtures, matchdays |
+| `chart-scales.ts`      | the chart components     | which band, which colour, which tick       |
+| `reference-mapping.ts` | the reference readers    | payload → row, row → domain, staleness     |
+
+**Keep that split.** A rule that only exists inside an `async` function wrapped around 344
+upstream calls cannot be tested, and every rule in `scoring.ts` has already been broken once
+in production:
 
 - an unscored gameweek must be **absent**, not zeros — `{}` is truthy, and zeros rank
 - ties share the higher rank and consume the lower ones (`1, 1, 3`)
 - `standings` with `total: 0` is post-draft, not a season — the derived sum stands
 
-Adding a rule to the scoring layer means adding the test that pins it. Component tests are a
-separate decision; there is no jsdom environment configured and no need for one yet.
+**A rule that decides a colour or a scale is a rule.** `chart-scales.ts` exists because five
+defects shipped while those rules lived as untested helpers inside chart components: an
+all-drawn head-to-head record painted as the heaviest defeat, contradicting the
+tie-is-a-draw rule that `scoring.ts` tests two files away; a grid that saturated to solid
+green and red one gameweek into a season, because every pair had met once so every ratio was
+1 or 0; a manager with no recent result sorting to the top of the form guide, because
+dividing by `played.length || 1` gave them an average of 0, which beats first place; a box
+plot rendering with no axis labels when scores cluster; and a bump chart rendering with no
+lines at all, after its series were keyed by league entry on one side and display name on
+the other. Typecheck, lint, tests and the build passed on every one of them. **Presentation
+logic fails silently — it renders something**, so it needs pinning more than logic that
+throws, not less.
+
+Adding a rule to any of those modules means adding the test that pins it. Component tests
+are a separate decision; there is no jsdom environment configured, so **layout is verified
+by eye, never by CI** — say so when a change is layout-only.
 
 CI is `.github/workflows/ci.yml`: `pnpm lint`, `typecheck`, `test` and `format:check` on
 every pull request and every push to `main`. Each step carries `if: '!cancelled()'` so one
@@ -427,7 +492,7 @@ Port 3000 is frequently taken by another project on this machine — a `307 → 
 **`rm -rf .next` before trusting any data-shape debugging.** Next persists its fetch cache
 across builds and will happily serve you last season's payload.
 
-`pnpm lint` currently reports **0 errors and 4 warnings**. The warnings are a known,
+`pnpm lint` currently reports **0 errors and 2 warnings**. The warnings are a known,
 pre-existing backlog — see below. Do not add to them.
 
 ---
@@ -450,17 +515,16 @@ pre-existing backlog — see below. Do not add to them.
 the Next 16 / React 19 upgrade that surfaced them. They are a backlog to work off. Fix the
 violations, then promote the rule back to `error` in `eslint.config.mjs`.
 
-| Rule                                 | Count | What it means here                                                             |
-| ------------------------------------ | ----- | ------------------------------------------------------------------------------ |
-| `@typescript-eslint/no-explicit-any` | 3     | Recharts tooltip/label payloads, and the generic row type in `base-table.tsx`. |
-| `import/no-anonymous-default-export` | 1     | `eslint.config.mjs` exporting its config array inline.                         |
+| Rule                                 | Count | What it means here                                     |
+| ------------------------------------ | ----- | ------------------------------------------------------ |
+| `@typescript-eslint/no-explicit-any` | 1     | The generic row type in `base-table.tsx`.              |
+| `import/no-anonymous-default-export` | 1     | `eslint.config.mjs` exporting its config array inline. |
 
 The `react-hooks` warnings are gone: `set-state-in-effect` and `exhaustive-deps` both came
 from client-side data fetching, which the Server Components refactor removed outright. The
 `no-explicit-any` count fell from ~26 to 3 when the upstream payloads were typed into
-[`src/interfaces/fpl.ts`](../src/interfaces/fpl.ts).
-
-Two further known defects, both pre-existing and neither yet fixed:
+[`src/interfaces/fpl.ts`](../src/interfaces/fpl.ts), and to 1 when the recharts tooltip and
+label payloads were typed.
 
 Both of the defects that used to be listed here are fixed. Inter is now mapped into the
 theme as `--font-sans`, so it is the sans face everywhere and no element needs a font

--- a/agents/API.md
+++ b/agents/API.md
@@ -598,6 +598,15 @@ never needs paging. `statuses=U,L,C` is upcoming, live and complete, which is ev
   `status` is `L`.
 - **`goals[]` carries `personId`, not a name.** Rendering scorers would need a further
   lookup; the app does not currently do it.
+- **Use `kickoff.label`, never `kickoff.millis`, for anything rendered.** The label is
+  already localised to UK time, which is the right zone for a Premier League kick-off, and
+  it is a string, so it renders identically on the server and in the browser. Formatting the
+  millis instead paints the server's timezone first and the reader's after hydration — a
+  visible flip and a hydration warning. `groupByDay` takes the matchday heading from
+  `"Sat 22 Aug 2026, 12:30 BST"` by one split on the comma, so the heading and the times
+  printed under it come from one string and cannot disagree.
+- **`kickoff` can be absent.** A fixture moved for television loses its slot for weeks;
+  those collect under `DATE_TBC` rather than being dropped or dated.
 - **`altIds.opta`** is `"g" + the classic API's fixture `code``, if a Premier League result
   ever needs joining to an FPL gameweek.
 

--- a/agents/ARCHITECTURE.md
+++ b/agents/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
 name: Better Draft — Architecture
-last_updated: 2026-08-13
+last_updated: 2026-08-15
 ---
 
 # Architecture
@@ -34,18 +34,21 @@ behind that gate, each enforced somewhere different:
   account clears it.
 - **A member** — that session's email also has a row in `league_members`. `getCurrentUser()`
   returns `null` for anyone else.
-- **Onboarded** — a display name and a bio are on record. `(app)/(onboarded)/layout.tsx`
-  sends anyone missing either to `/profile` and keeps them there.
+- **Onboarded** — a display name, a bio **and** a favourite club are on record.
+  `(app)/(onboarded)/layout.tsx` sends anyone missing any of the three to `/profile` and
+  keeps them there. `isProfileComplete` in `src/server/auth/server.ts` is the one place that
+  decides; the `required` attributes on the form are a courtesy.
 
 `/profile` is the funnel for the two failure cases, which is why it sits outside
 `(onboarded)`: a stranger sees why they are not in, a member sees the form.
 
 The product surface:
 
-- `/` — the standings table (F1 scoring) and position distribution
+- `/` — the standings board, and a season tab of charts plus a rivals tab of comparisons
 - `/results` — per-gameweek results, charts and detail views
 - `/rumblers` — the last-place hall of shame
 - `/squads` — one squad at a time, with a second beside it to compare against; each row carries the player's club and season points
+- `/premier-league` — the **real** league table, and every fixture and result
 - `/players/[playerId]` — one manager's season: performance, positions, form
 - `/profile` — claim which manager you are (members only)
 - `/auth/sign-in` — the only route a signed-out visitor can reach
@@ -55,6 +58,15 @@ and are read from the FPL API. What the database holds is exactly two things: **
 immutable facts** (finished gameweek scores, so we don't refetch a season of history on
 every cold start) and **data with no upstream source at all** (profiles, and later bets).
 The F1 scoring table itself is neither — it is _our policy_, and it lives in code.
+
+**There are three upstreams, not two.** Neither FPL game can answer "what is the Premier
+League table?" — the classic bootstrap carries `played`, `win`, `draw`, `loss`, `points` and
+`position` on every club and leaves every one of them at zero. So `/premier-league` reads
+the **Pulse API** behind premierleague.com instead. Deriving a table from finished fixtures
+was considered and rejected: it cannot see a points deduction, so it would disagree with the
+official table by a few points in exactly the season where that matters, and it would do it
+silently. **There is deliberately no fallback** — if Pulse is unreachable the page says so.
+A page whose whole point is being authoritative must fail loudly rather than serve a guess.
 
 ---
 
@@ -83,10 +95,12 @@ connection string is a real credential, and it must never reach the browser.
 │   src/server/data/**         ── the DAL: one module per domain    │
 │   src/server/db/client.ts    ── ONLY file that builds a db client │
 │   src/utils/gameweek-data.ts ── score · rank · aggregate          │
+│   src/utils/premier-league-data.ts ── the Pulse table + fixtures  │
 │   src/utils/fpl-api.ts       ── ONLY file with upstream URLs      │
 └──────────────│──────────────────────────────│─────────────────────┘
                ▼                              ▼
    Neon Postgres (+ neon_auth)   draft.premierleague.com · fantasy.…
+                                 footballapi.pulselive.com
 ```
 
 Two rules follow, and neither has exceptions:
@@ -171,6 +185,7 @@ Two consequences worth stating outright:
     │   │       ├── results/   /results
     │   │       ├── rumblers/  /rumblers
     │   │       ├── squads/    /squads
+    │   │       ├── premier-league/  /premier-league — the real table (Pulse)
     │   │       └── players/[playerId]/  /players/:id
     │   └── api/               Neon Auth + the cron sync job (see API.md)
     ├── components/
@@ -179,8 +194,9 @@ Two consequences worth stating outright:
     │   ├── PlayerView/        per-player charts, summary, form guide
     │   ├── RumblerView/       rumbler cards, dashboard, frequency chart
     │   ├── SquadView/         squad card + the picker that chooses one or two
-    │   ├── Layout/            AppChrome, HeaderNav, SideNav, MobileNav, Footer
-    │   └── DetailView/        gameweek summary, score chart, match odds
+    │   ├── PremierLeagueView/ the real table, fixtures and results
+    │   ├── Profile/           the onboarding form
+    │   └── Layout/            AppChrome, HeaderNav, SideNav, MobileNav, Footer
     ├── server/                ★ server-only. Never imported by a client component.
     │   ├── db/
     │   │   ├── client.ts      ★ the ONLY file that builds a db client
@@ -205,6 +221,10 @@ Two consequences worth stating outright:
         ├── fpl-api.ts         ★ server-only. Upstream API URLs + FPL_LEAGUE_ID. The gateway.
         ├── pl-assets.ts       crest + headshot URLs (browser-loaded, so not in fpl-api)
         ├── gameweek-data.ts   ★ the data layer: fetch, score, rank, aggregate, cache
+        ├── scoring.ts         ★ pure: ranks, F1 points, rumblers — the tested rules
+        ├── premier-league.ts  ★ pure: Pulse payload → table, fixtures, matchdays
+        ├── premier-league-data.ts  the Pulse fetch + cache (no fallback, by design)
+        ├── chart-scales.ts    ★ pure: which band, which ramp step, which tick
         ├── reference-mapping.ts ★ pure: payload→row, row→domain, REFERENCE_STALE_AFTER_SECONDS
         ├── draft-elements.ts  the element lookup: tables first, bootstrap fallback
         ├── pl-teams.ts        the 20 clubs: table first, bootstrap fallback
@@ -281,6 +301,19 @@ The guard that keeps this safe: a gameweek that produced **no** performances is 
 recorded. An unscored gameweek must stay absent so it is retried, rather than being frozen
 into the database as a set of zeros — which is the persistent version of the bug where all
 eight managers tied on rank 1 and banked a win.
+
+**A new cached read is not finished until the cron job knows about it.** `TAGS` in
+`/api/cron/revalidate` is a hand-written list, so a `cachedRead` whose tag is missing from it
+is simply never revalidated — nothing warns, and the page just serves an older answer than
+everything beside it. The Pulse reads shipped that way and had to be registered afterwards.
+Adding a tag means adding it to that list in the same change.
+
+**A module-level memo sits outside every layer in the table above.** `clearCache()` drops
+what `cachedRead` owns; nothing drops a `let` at module scope. That is deliberate for the
+Pulse `compSeasons` ID and for the club list — both change once a year, serverless instances
+are short-lived, and the worst case is one instance reading last season for a few minutes at
+the one moment anyone would notice. It is the wrong shape for anything that changes within a
+season, because there is no way to invalidate it short of a deploy.
 
 > [!WARNING]
 > The Next.js `fetch` cache **persists in `.next/cache` across builds**. A stale
@@ -400,23 +433,25 @@ integrity cost of leaving it off is nil.
 
 ## 7. Where to start — entry points by task
 
-| Task                                    | Start here                                | Then                                                          |
-| --------------------------------------- | ----------------------------------------- | ------------------------------------------------------------- |
-| Add a new upstream call                 | `src/utils/fpl-api.ts`                    | Document the shape in [`API.md`](./API.md)                    |
-| Change how scoring or ranking works     | `src/utils/gameweek-data.ts`              | `F1_POINTS`, `assignRanks`, §5 above                          |
-| Add an API route                        | `src/app/api/<name>/route.ts`             | Copy the `{ error, message }` contract                        |
-| Add a page                              | `src/app/<route>/page.tsx`                | [`FRONTEND.md`](./FRONTEND.md)                                |
-| Add a table                             | `src/components/TableView/base-table.tsx` | `table-configs.tsx`                                           |
-| Add a chart                             | `src/components/ui/chart.tsx`             | An existing chart in `PlayerView/`                            |
-| Change theme colours or radii           | `src/app/globals.css` (`@theme inline`)   | [`FRONTEND.md`](./FRONTEND.md) — tokens, not hex              |
-| Add a shadcn primitive                  | `pnpm dlx shadcn@latest add <component>`  | `components.json` is already v4-shaped                        |
-| Debug "the data looks like last season" | `rm -rf .next`                            | §6 above, then [`API.md`](./API.md)                           |
-| Point the app at a different league     | `.env.local` → `FPL_LEAGUE_ID`            | [`API.md`](./API.md#the-league-id-is-an-environment-variable) |
-| Add a table or change the schema        | `src/server/db/schema.ts`                 | `pnpm db:generate` then `pnpm db:migrate`                     |
-| Add a database read                     | `src/server/data/<domain>.ts`             | Never `@/server/db/**` from a page or route                   |
-| Add a write                             | `src/server/actions/<domain>.ts`          | Validate, call the DAL, `revalidatePath`                      |
-| Gate something behind sign-in           | already gated — `src/proxy.ts`            | For members-only, check `getCurrentUser()` in the page too    |
-| Add someone to the league               | `league-members.json`                     | `pnpm db:seed:members`                                        |
+| Task                                    | Start here                                | Then                                                               |
+| --------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------ |
+| Add a new upstream call                 | `src/utils/fpl-api.ts`                    | Document the shape in [`API.md`](./API.md)                         |
+| Change how scoring or ranking works     | `src/utils/scoring.ts`                    | `F1_POINTS`, `assignRanks`, §5 above — add the test                |
+| Change the real Premier League table    | `src/utils/premier-league.ts`             | `premier-league-data.ts` for the fetch; [`API.md`](./API.md)       |
+| Change a chart's colours or bands       | `src/utils/chart-scales.ts`               | Never inside the component — [`FRONTEND.md`](./FRONTEND.md)        |
+| Add an API route                        | `src/app/api/<name>/route.ts`             | Copy the `{ error, message }` contract                             |
+| Add a page                              | `src/app/<route>/page.tsx`                | [`FRONTEND.md`](./FRONTEND.md)                                     |
+| Add a table                             | `src/components/TableView/base-table.tsx` | `table-configs.tsx`                                                |
+| Add a chart                             | `ChartCard` + `ChartContainer`            | An existing chart on the season tab; rules go in `chart-scales.ts` |
+| Change theme colours or radii           | `src/app/globals.css` (`@theme inline`)   | [`FRONTEND.md`](./FRONTEND.md) — tokens, not hex                   |
+| Add a shadcn primitive                  | `pnpm dlx shadcn@latest add <component>`  | `components.json` is already v4-shaped                             |
+| Debug "the data looks like last season" | `rm -rf .next`                            | §6 above, then [`API.md`](./API.md)                                |
+| Point the app at a different league     | `.env.local` → `FPL_LEAGUE_ID`            | [`API.md`](./API.md#the-league-id-is-an-environment-variable)      |
+| Add a table or change the schema        | `src/server/db/schema.ts`                 | `pnpm db:generate` then `pnpm db:migrate`                          |
+| Add a database read                     | `src/server/data/<domain>.ts`             | Never `@/server/db/**` from a page or route                        |
+| Add a write                             | `src/server/actions/<domain>.ts`          | Validate, call the DAL, `revalidatePath`                           |
+| Gate something behind sign-in           | already gated — `src/proxy.ts`            | For members-only, check `getCurrentUser()` in the page too         |
+| Add someone to the league               | `league-members.json`                     | `pnpm db:seed:members`                                             |
 
 ---
 

--- a/agents/FRONTEND.md
+++ b/agents/FRONTEND.md
@@ -42,15 +42,17 @@ genuinely needs the browser.
 
 Components are grouped by the view they serve, not by type:
 
-| Folder                        | Holds                                                                                                                         |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `src/components/ui/`          | shadcn primitives. Nothing app-specific.                                                                                      |
-| `src/components/TableView/`   | Standings, draft results, position tables, and the table base                                                                 |
-| `src/components/PlayerView/`  | Per-player charts, summary cards, form guide                                                                                  |
-| `src/components/RumblerView/` | Rumbler cards, dashboard, frequency chart                                                                                     |
-| `src/components/DetailView/`  | Gameweek summary, score chart, match odds                                                                                     |
-| `src/components/Layout/`      | `HeaderNav`, `MobileNav`, `Footer`                                                                                            |
-| `src/components/*.tsx` (root) | Genuinely cross-view pieces only — `ErrorDisplay`, `SkeletonTable`, `GameweekSelector`, `PlayerLink`, `Select`, `ViewButtons` |
+| Folder                              | Holds                                                                                                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/components/ui/`                | shadcn primitives. Nothing app-specific.                                                                                                         |
+| `src/components/TableView/`         | Standings, draft results, position tables, and the table base                                                                                    |
+| `src/components/PlayerView/`        | Per-player charts, summary cards, form guide                                                                                                     |
+| `src/components/RumblerView/`       | Rumbler cards, dashboard, frequency chart                                                                                                        |
+| `src/components/SquadView/`         | Squad card and the picker that chooses one squad or two                                                                                          |
+| `src/components/PremierLeagueView/` | The real league table, fixtures and results                                                                                                      |
+| `src/components/Profile/`           | The onboarding form and its pieces                                                                                                               |
+| `src/components/Layout/`            | `AppChrome`, `HeaderNav`, `SideNav`, `MobileNav`, `Footer`                                                                                       |
+| `src/components/*.tsx` (root)       | Genuinely cross-view pieces only — `ErrorDisplay`, `SkeletonTable`, `GameweekSelector`, `PlayerLink`, `SectionTabs`, `ChartCard`, and a few more |
 
 A component used by exactly one view belongs in that view's folder. Promote to the root only
 when a second view imports it.
@@ -84,6 +86,13 @@ beats any class, so the two mechanisms could not be mixed on one table. **`hideB
 (`'sm' | 'md' | 'lg'`) hides a column's header and its cells together; never write
 `hidden md:table-cell` into `className` and `cellClassName` by hand, because the two halves
 have to agree.
+
+`hideBelow` resolves through the `HIDDEN_BELOW` literal map, and it must stay a literal map.
+Building `` `hidden ${hideBelow}:table-cell` `` at runtime is a class Tailwind's scanner
+never sees, so it generated no rule and every `sm` and `lg` column was invisible at **every**
+width for as long as the code existed. See
+[`AGENTS.md`](./AGENTS.md#never-assemble-a-tailwind-class-name-at-runtime) — the same trap
+applies to any class a variable picks.
 
 **A column config may be a function** when a cell needs something the component owns —
 `draftResultsColumns(onViewTeam)`. Columns stay data and stay in `table-configs.tsx`
@@ -131,9 +140,60 @@ data as a prop has no loading state and no error state to render.
 - **`ChartTooltipContent` is the tooltip.** Don't build a custom one.
 - **Chart colours come from `ChartConfig` or `src/utils/tailwindVars.ts`**, not inline hex
   in the chart body.
+- **`ChartCard` is the wrapper**, not a hand-rolled `Card` + `CardHeader` + `CardTitle`. It
+  owns the title size, the caption, and the `action` slot beside the title. Per-chart
+  variation goes in `contentClassName`, which is the only thing that genuinely differs.
 - Charts are client components by necessity — recharts needs the DOM. Keep the data shaping
   outside the component where you can, so the refactor to Server Components only has to move
   the fetch.
+
+### Aspect ratio is `aspect-video`, and it lives in the primitive
+
+`ChartContainer` defaults to `aspect-video`, not stock shadcn's `aspect-square`. A square is
+wrong at both ends of the layout: at half width it towers over the card beside it, and at
+full width it is as tall as the page is wide, which flattens every crossing on a line chart.
+
+The lesson is the location of the fix, not the ratio. **Three consumers had each overridden
+it independently before anyone changed the default** — a defect rediscovered more than once
+belongs in the primitive. If you find yourself passing the same override a third time, that
+is the signal.
+
+### The rules that pick a colour or a scale live in `chart-scales.ts`
+
+**Never derive a band, a ramp step, an axis tick or a series key inside a chart component.**
+Those are rules, and rules go in [`src/utils/chart-scales.ts`](../src/utils/chart-scales.ts)
+with tests beside them — `versusBand`, `heatStep`, `scaleTicks`, `seriesKey`, `bumpSeries`.
+Five shipped defects lived in exactly that code while it was untested helpers inside
+components; [`AGENTS.md`](./AGENTS.md#testing) lists them. Presentation logic never throws,
+so nothing catches it but a test or an eye.
+
+Two encoding rules follow from the same rework:
+
+- **Encode magnitude, not only order.** A rank tells you who won; it cannot tell a one-point
+  defeat from a hammering. If every chart on a page encodes rank, one of them should be
+  showing margin instead.
+- **Ordinal data gets a single-hue ramp, never a rainbow.** `--color-heat-*` is the
+  sequential ramp for magnitude and `--color-versus-*` the diverging one for a two-sided
+  comparison, both defined in `globals.css`. Categorical hues are for identity
+  (`--color-series-*`) and nothing else. A diverging cell must print its number as well as
+  its colour.
+- **Floor a ratio on small samples.** One gameweek into a season every pair has met once, so
+  every ratio is 1 or 0 and the whole grid saturates. Outer bands require
+  `MIN_DECISIVE_MEETINGS`; anything that colours by proportion needs the same floor.
+
+### Choose the axis the reader will compare along
+
+Two shapes on the season tab were wrong for the question they answered, and both failures
+were about what the eye can compare:
+
+- **A stacked bar whose total is constant carries no information in its length.** Every
+  manager plays the same number of gameweeks, so only the segment boundaries meant anything,
+  and reading them asked for eight length comparisons buried inside one bar. A grid puts the
+  same numbers on a shared scale: a column reads down, a row reads across.
+- **A "last five" window must be chosen once for the card, not per row.** Taking each
+  manager's own last five results and padding short rows meant a column could mean different
+  gameweeks on different rows. Pick the gameweeks for the card, then look each manager up by
+  event.
 
 ---
 
@@ -147,14 +207,28 @@ data as a prop has no loading state and no error state to render.
 - **The palette is HSL triplets in `:root`**, consumed as `hsl(var(--token))`. Keep that
   indirection: it is what makes the planned design refresh a single-file change.
 
+- **A `backdrop-filter` promotes its whole subtree onto one composited layer**, where
+  fractional pixel positions stop being snapped and text and icons read as slightly out of
+  focus. That is what the `glass-panel` utility exists for: it paints the blur on a
+  `::before` **behind** the panel, so the panel's own children stay on the normal layer. Use
+  it rather than putting `backdrop-blur` on a container that holds content, and use `.glass`
+  only for a purely decorative surface.
+- **A hand-written rule in `globals.css` is unlayered, and unlayered beats `@layer
+utilities`** — which is every Tailwind utility. `glass-panel` deliberately sets no
+  `position` for exactly that reason: a `position: relative` there silently overrode the
+  `fixed` on both navigations and dropped them into the page flow. A custom class states
+  only what cannot be a utility, and the caller keeps positioning.
+
 > **Known drift.** A number of components still hard-code the brand purple as
 > `bg-[#2a0d33]`, `bg-[#1a0520]` and `border-white/10` — including `ErrorDisplay` and
-> several cards. That predates this rule. Don't add more; fold the existing ones into the
-> design refresh.
+> several cards, 77 occurrences at the last count. That predates this rule. Don't add more;
+> fold the existing ones into the design refresh.
 
-> **Known bug.** `font-inter` is applied to `<body>` but no theme entry maps it, so the app
-> renders in the default sans stack despite loading Inter. Fixing it changes the typography
-> of the whole app, so it belongs to the design refresh rather than a drive-by edit.
+> **Check the token before trusting a `hover:` variant.** A stock variant is written against
+> stock tokens, and ours are not stock: `--accent` here is a saturated cyan, not a near-white
+> tint. The "View team" button went out illegible because its hover background and its hover
+> text resolved to the same cyan. Read what the token actually is before relying on a
+> variant's built-in hover pair.
 
 ---
 


### PR DESCRIPTION
Reviews the six PRs merged this week and folds their durable, non-obvious lessons into the
backbone docs, correcting what had gone stale on the way. **Docs only** — no source changed.

## New law: never assemble a Tailwind class name at runtime

The one law-grade lesson in the batch, from #19, and it now sits in AGENTS.md under Styling.

Tailwind scans **source text**, so a class built from a variable is one it has never seen and
generates no rule for. Nothing fails: not the build, not the typecheck, not lint.

```ts
// ✗ compiles, typechecks, and silently produces no CSS
return `hidden ${hideBelow}:table-cell`;
```

`hiddenClasses` shipped exactly that, so every column marked `sm` or `lg` kept its `hidden`
and never got `table-cell` back — invisible at **every** width rather than hidden below one.
The failure mode is what makes it law-grade: a missing column reads as a design decision, so
it survives review. It took someone asking where the form column had gone.

## The pure/impure split, generalised

AGENTS.md said "test the scoring layer". There are now four such pairs, so the rule is stated
as the pattern it actually is:

| Pure (tested) | Impure sibling | What the rules decide |
| --- | --- | --- |
| `scoring.ts` | `gameweek-data.ts` | ranks, F1 points, rumblers |
| `premier-league.ts` | `premier-league-data.ts` | Pulse payload → table, fixtures, matchdays |
| `chart-scales.ts` | the chart components | which band, which colour, which tick |
| `reference-mapping.ts` | the reference readers | payload → row, staleness |

With the argument #17 and #20 supply: **presentation logic never throws, it renders
something**, so it needs pinning more than logic that fails loudly. The five defects that
shipped from untested helpers inside chart components — the all-drawn record painted as the
heaviest defeat, the grid saturating one gameweek in, the no-result manager sorting to the
top, the axis with no labels, the bump chart with no lines — are the evidence, and every one
of them passed typecheck, lint, tests and the build.

## ARCHITECTURE.md did not know Pulse or `/premier-league` existed

A grep for "pulse" or "premier" in the request-flow document returned nothing. Adds the third
upstream with #18's reasoning — neither FPL game can answer "what is the table?", and
deriving one from finished fixtures cannot see a points deduction, so it would disagree with
the official table by a few points in exactly the season where that matters, silently. Hence
no fallback. Plus the route, the components, the pure modules, the diagram, and two caching
rules learned on that branch:

- **A new cached read is not finished until the cron job knows about it.** `TAGS` is a
  hand-written list; a tag missing from it is simply never revalidated, and nothing warns.
- **A module-level memo sits outside every cache layer.** `clearCache()` drops what
  `cachedRead` owns; nothing drops a `let` at module scope. Right for the Pulse season ID,
  wrong for anything that changes within a season.

## FRONTEND.md

The `aspect-video` default and **why the fix belonged in the primitive** — three consumers
had each overridden it independently, which is the signal. The rule that colour and scale
logic lives in `chart-scales.ts`. Three encoding rules (encode magnitude not only order;
ordinal data gets a single-hue ramp, never a rainbow; floor a ratio on small samples). The
two chart-shape lessons — a stacked bar whose total is constant carries no information in its
length, and a "last five" window must be chosen once for the card, not per row. And
`glass-panel`, including the trap that an unlayered rule in `globals.css` beats every
Tailwind utility, which is why it must not set `position`.

## API.md

Pulse was already well covered by #18. One addition, from #19: render the matchday from
`kickoff.label`, never `kickoff.millis`. The millis paint the server's timezone first and the
reader's after hydration — a visible flip and a hydration warning — and would let the heading
disagree with the times printed beneath it.

## Stale facts corrected

Checking every claim against the tree rather than taking it from the PR bodies is what caught
these:

- `pnpm lint` reports **0 errors and 2 warnings**, not 4. `no-explicit-any` is 1, not 3.
- A "Two further known defects, both pre-existing and neither yet fixed" line sat directly
  above a paragraph explaining that both are fixed.
- The `font-inter` "Known bug" note in FRONTEND.md described a bug fixed some time ago.
- `DetailView/` no longer exists; `PremierLeagueView/`, `SquadView/` and `Profile/` do.
- Onboarding requires a favourite club as well as a name and a bio.
- One claim I had drafted from #18's body — that `outline`'s `hover:bg-accent` is still
  cyan-on-cyan — was wrong at the current tree, and is rephrased as the general lesson
  (check the token before trusting a stock variant's hover pair).

## Verification

`pnpm lint` (0 errors, the 2 known warnings), `pnpm test` (142 passing) and
`pnpm format:check` all pass. `typecheck` and `build` are unaffected — no source file is
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
