### PR TITLE
fix: never finalise a gameweek that is still being played

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -201,13 +201,19 @@ tolerable because it happens once per server, behind a cache, not once per visit
 
 ## Read API.md before you fetch
 
-The FPL APIs are undocumented, unversioned, and change shape between seasons. Three
-specific behaviours have already caused real bugs in this repo:
+The FPL APIs are undocumented, unversioned, and change shape between seasons. Every one of
+these behaviours has already caused a real bug in this repo:
 
 - `/api/pl/event-status` **404s with the bare string `"Game not started"`** out of season —
   not an object. Destructuring it throws.
+- `/api/pl/event-status` returns **one row per date, not per gameweek**. `leagues_updated`
+  goes true on a gameweek's opening Friday night with three days still to play, so
+  `some(leagues_updated)` declares it complete. Ask `deriveSeasonState()`.
 - `/api/event/{gw}/live` returns `elements: {}` for unscored gameweeks, and **`{}` is
   truthy**. A naive guard lets every player score 0, tie on rank 1, and bank a win.
+- `/api/event/{gw}/live` then returns **all ~609 elements on zero** from the moment the
+  gameweek's fixtures exist, hours before kick-off. Counting keys does not catch that one.
+  Ask `hasBeenPlayed()`.
 - **`league_entries[].id` and `league_entries[].entry_id` are different numbers.** `id` is
   the league entry (what we use as the player ID everywhere); `entry_id` goes in
   `/api/entry/...` URLs.
@@ -254,6 +260,38 @@ awards points.
 **And `0` is a real value, not "not yet".** Test `typeof score === 'number'`, never
 truthiness, or a completed goalless draw renders as a fixture still to kick off. Any field
 where "none" and "not known yet" are both plausible needs the same care.
+
+**Nor is a full collection proof of data.** Both traps above are the same mistake at two
+scales: `{}` is the empty shape, and 609 elements on `minutes: 0` is the _populated_ shape
+of the same nothing. Counting the container answers a question about the container. Ask
+whether anything inside it actually happened.
+
+### A gameweek is over when two sources agree, and never before
+
+This is the most expensive rule in the codebase, because getting it wrong is
+**unrecoverable without a manual delete**. `gameweek_scores` is written
+`onConflictDoNothing` and a finalised gameweek is never refetched, so a gameweek stored
+early stays wrong for the season.
+
+It cost a real one. On 2026-08-21, before a ball was kicked in GW1, `event-status` said
+`leagues_updated` for that day and the live feed had 609 elements in it. The app wrote all
+eight managers on 0 points, tied on rank 1 — a win and 20 F1 points each — and served that
+for three days.
+
+- **`deriveSeasonState()` in `src/utils/season-state.ts` is the only place that decides.**
+  A gameweek below `current_event` is over; `current_event` itself is over only when
+  `/api/game` says `current_event_finished` **and** every `event-status` row for it says
+  `leagues_updated`.
+- **The gameweek in flight is shown, never stored.** It is scored by the same rule, marked
+  `finished: false`, named in `provisionalGameweek`, and recomputed on every cache miss.
+  Hiding it would make the site wrong on the one day everybody looks at it; showing it as
+  settled would be worse. Every surface that renders a rank drawn from it says so.
+- **`storeFinalisedGameweeks` refuses what it must not freeze** — anything provisional,
+  and any gameweek where every manager scored 0. It filters and logs rather than throwing,
+  because every page render goes through its caller and refusing the write is the whole
+  job.
+- **The escape hatch is `scripts/forget-gameweek.mjs`.** If a bad row is already stored,
+  no amount of correct code removes it.
 
 ---
 
@@ -351,6 +389,9 @@ where "none" and "not known yet" are both plausible needs the same care.
 - Never persist a row without `league_id`, or query one without filtering on it. A league id
   is a season id; both FPL identifiers are minted fresh each August.
 - Never store a gameweek that produced no performances; it must stay absent and be retried.
+- Never store a gameweek that is still being played, and never decide that anywhere other
+  than `deriveSeasonState()`.
+- Never render a provisional rank, F1 score or position without saying it is provisional.
 
 ---
 
@@ -439,6 +480,7 @@ into it.
 | `premier-league.ts`    | `premier-league-data.ts` | Pulse payload → table, fixtures, matchdays |
 | `chart-scales.ts`      | the chart components     | which band, which colour, which tick       |
 | `reference-mapping.ts` | the reference readers    | payload → row, row → domain, staleness     |
+| `season-state.ts`      | `gameweek-data.ts`       | which gameweek is in play, which are over  |
 
 **Keep that split.** A rule that only exists inside an `async` function wrapped around 344
 upstream calls cannot be tested, and every rule in `scoring.ts` has already been broken once

--- a/agents/API.md
+++ b/agents/API.md
@@ -1,6 +1,6 @@
 ---
 name: Better Draft — API reference
-last_updated: 2026-08-15
+last_updated: 2026-08-24
 ---
 
 # API.md — Every API We Call, and What Comes Back
@@ -97,8 +97,12 @@ A third trap is not season-related but caused the same symptom:
 ### `GET /api/game`
 
 Game-wide state. **Available year-round**, which makes it the dependable way to ask
-whether the season has started. Not currently called by the app; prefer it over
-`event-status` for any new "is the season live?" logic.
+whether the season has started — and the senior half of the "is this gameweek over?"
+decision, because `event-status` cannot answer it alone (see the warning below it).
+
+`current_event` is `null` pre-season. `current_event_finished` flips when the last
+whistle of the gameweek blows, which is _earlier_ than `leagues_updated` — that one waits
+for the draft league to be scored, bonus points included. The app requires both.
 
 ```json
 {
@@ -113,28 +117,68 @@ whether the season has started. Not currently called by the app; prefer it over
 
 ### `GET /api/pl/event-status`
 
-Per-gameweek processing status. Drives which gameweeks are considered complete.
+Processing status. Read the warning before using it — the name and the field names both
+describe a gameweek, and the payload is a gameweek's **match days**.
+
+Observed 2026-08-24, mid-GW1:
 
 ```json
 {
   "status": [
     {
-      "bonus_added": true,
-      "date": "2026-05-01",
-      "event": 35,
+      "bonus_added": false,
+      "date": "2026-08-21",
+      "event": 1,
       "leagues_updated": true,
-      "points": "r"
+      "points": "p"
+    },
+    {
+      "bonus_added": false,
+      "date": "2026-08-22",
+      "event": 1,
+      "leagues_updated": true,
+      "points": "p"
+    },
+    {
+      "bonus_added": false,
+      "date": "2026-08-23",
+      "event": 1,
+      "leagues_updated": true,
+      "points": "p"
+    },
+    {
+      "bonus_added": false,
+      "date": "2026-08-24",
+      "event": 1,
+      "leagues_updated": false,
+      "points": ""
     }
   ],
-  "leagues": "Updated"
+  "leagues": ""
 }
 ```
 
-- `leagues_updated: true` means that gameweek's league scoring is final. This is the
-  field `getGameweekData()` uses to decide `maxCompletedGameweek`.
+> [!WARNING]
+> **One row per date, not per gameweek.** `leagues_updated` means "the league table was
+> brought up to date after _that day's_ matches", so it goes true on the opening Friday
+> night with three days of football still to play. `status.some((s) => s.leagues_updated)`
+> — or `Math.max` over the filtered rows — therefore reports the gameweek complete while
+> it is still being played. That is exactly what happened to GW1 of 2026/27: combined
+> with the all-zero live feed below, the app wrote eight managers on 0 points and joint
+> first into `gameweek_scores` as final, paying every one of them a win and 20 F1 points.
+> A finalised gameweek is never refetched, so it stayed wrong until the rows were
+> deleted by hand.
+>
+> A gameweek is finished only when **every** row for that event says `leagues_updated`
+> **and** `/api/game` says `current_event_finished`. That rule lives in one place:
+> `deriveSeasonState()` in [`src/utils/season-state.ts`](../src/utils/season-state.ts).
+
+- Rows only cover the current gameweek's dates, so nothing in this payload can speak for
+  earlier gameweeks. `current_event` moving on is the evidence that those are done.
 - **404s pre-season** with the bare string `"Game not started"` — see the warning above.
 
-Consumed by: `fetchEventStatus()` in `gameweek-data.ts`.
+Consumed by: `fetchEventStatus()` in `gameweek-data.ts`, and only ever through
+`deriveSeasonState()`.
 
 ### `GET /api/league/{leagueId}/details`
 
@@ -257,10 +301,20 @@ Live per-player stats for one gameweek. Two keys: `elements` and `fixtures`.
 }
 ```
 
-The app reads exactly one field: `elements[id].stats.total_points`.
+The app reads two fields: `elements[id].stats.total_points` to score, and
+`elements[id].stats.minutes` to decide whether the gameweek has started at all.
 
-> _Unverified pre-season_ — `elements` is `{}` today, so the inner `stats` shape above
-> is from the code's usage, not an observed payload. Confirm after GW1.
+Verified 2026-08-24, mid-GW1: 609 elements, 279 of them with `minutes > 0`.
+
+> [!WARNING]
+> **A full `elements` map is not the same as a scored gameweek.** There are two "nothing
+> yet" shapes and they arrive in sequence: `{}` before the gameweek's fixtures exist, then
+> **every element in the game on `minutes: 0` and `total_points: 0`** from the moment they
+> do — hours before kick-off. `Object.keys(elements).length === 0` catches the first and
+> not the second, which is how eight managers summed to 0, tied on rank 1, and were
+> written to the database as final. Go through `hasBeenPlayed()` in
+> [`src/utils/scoring.ts`](../src/utils/scoring.ts), which asks whether anyone has
+> actually taken the field.
 
 ### `GET /api/entry/{entryId}/event/{gameweek}`
 
@@ -280,9 +334,20 @@ sheet in the results drawer — a historical question, which is why it uses pick
 than `element-status` the way the squads page does. It treats the 404 as "no team sheet",
 which is an empty state, not an error.
 
-> _Still 404 as of 2026-08-13_, the day after the draft — the endpoint stays unavailable
-> until GW1 is actually played, not merely until squads exist. **To read a squad before the
-> season starts, use `element-status` instead.** Confirm the full pick shape after GW1.
+Verified 2026-08-24: `picks[]` carries `element`, `position`, `is_captain`,
+`is_vice_captain` and `multiplier`. The draft game has no captaincy, so `multiplier` is
+`1` on all fifteen and the app ignores it.
+
+> _404 as of 2026-08-13_, the day after the draft — the endpoint stays unavailable until
+> the gameweek's deadline passes, not merely until squads exist. **To read a squad before
+> the season starts, use `element-status` instead.**
+
+> [!NOTE]
+> **The starting-XI sum can differ from `standings[].event_total` by a point or two
+> mid-gameweek**, because the standings table refreshes on its own schedule while the live
+> feed is immediate. Observed on 2026-08-24: one manager on 26 by our sum, 24 upstream.
+> The app prefers its own sum — it is fresher, and it is the same rule used for every
+> finalised gameweek, so a provisional rank does not change method when it settles.
 
 ### `GET /api/league/{leagueId}/element-status`
 
@@ -705,14 +770,20 @@ on zero, and results and rumblers show their empty-state copy.
 [`src/utils/gameweek-data.ts`](../src/utils/gameweek-data.ts) is the whole data layer.
 One call:
 
-1. Reads `FPL_LEAGUE_ID`, then fetches league details and event status in parallel.
-2. Derives `maxCompletedGameweek` from `status[].leagues_updated`.
-3. For every completed gameweek, fetches the live data **and all 8 entries' picks**,
-   in batches of 5 gameweeks.
+1. Reads `FPL_LEAGUE_ID`, then fetches league details, event status, `/api/game` and the
+   two database reads in parallel.
+2. Derives `{ currentGameweek, finalisedThrough }` through `deriveSeasonState()` — the
+   only place "is this gameweek over?" is decided.
+3. For every **finalised** gameweek not already stored, fetches the live data **and all 8
+   entries' picks**, in batches of 5, and writes the result to `gameweek_scores`.
 4. Sums `total_points` over each entry's starting XI (`position <= 11`).
 5. Ranks the 8 entries within the gameweek and awards F1 points —
    `[20, 15, 12, 10, 8, 6, 4, 2]`.
-6. Aggregates into `players`, `rumblerData`, `completedGameweeks`.
+6. **Scores the gameweek in flight the same way and never stores it**, marking it
+   `finished: false` and naming it in `provisionalGameweek`. A league table that ignores
+   the weekend being played is wrong on the one day everybody looks at it; a provisional
+   rank shown as settled is worse. Both are needed, which is what the flag is for.
+7. Aggregates into `players`, `rumblerData`, `scoredGameweeks`.
 
 **The cost is the problem.** Each gameweek costs `1 + 8 = 9` upstream calls, and the
 whole history is recomputed from scratch:
@@ -724,11 +795,17 @@ whole history is recomputed from scratch:
 | 20                  | 180            |
 | 38                  | 342            |
 
-Plus two fixed calls. Two caches sit in front of this — a 1-hour TTL `Map` in
-`src/utils/cache.ts` with promise deduplication, and Next's own `fetch` cache
+Plus three fixed calls, and nine more for the gameweek in flight, which is recomputed on
+every cache miss rather than stored. Two caches sit in front of this — a 5-minute TTL
+`Map` in `src/utils/cache.ts` with promise deduplication, and Next's own `fetch` cache
 (`revalidate: 300`) — but **the `Map` is module scope, so it dies with every
 serverless instance.** On Vercel, a cold request late in the season pays the full
 344-call bill.
+
+The TTL matches the `revalidate` on the calls beneath it. It was an hour, on the
+reasoning that FPL data changes once per gameweek; that stopped being true when the
+season started including the gameweek in progress, and caching an aggregate for longer
+than its own inputs froze a live score at whatever it was an hour ago.
 
 That cost, not upstream latency, is the argument for persisting finished gameweeks.
 See [ARCHITECTURE.md → Where to draw the persistence line](./ARCHITECTURE.md#where-to-draw-the-persistence-line).

--- a/scripts/forget-gameweek.mjs
+++ b/scripts/forget-gameweek.mjs
@@ -1,0 +1,97 @@
+/**
+ * Delete a stored gameweek so the app refetches and re-scores it.
+ *
+ *   node --env-file=.env.local scripts/forget-gameweek.mjs <gameweek> [--prod]
+ *
+ * A gameweek in `gameweeks` is a claim that its result will never change again,
+ * and the insert behind it is `onConflictDoNothing` — so a gameweek stored
+ * wrongly cannot be corrected by any later run of the app. This is the escape
+ * hatch, and it is a script rather than a page because it is an administrative
+ * act on a table of facts.
+ *
+ * **Why it exists.** GW1 of 2026/27 was written on the Friday evening, before a
+ * ball was kicked, as eight managers on zero points and joint first — paying
+ * every one of them a win and 20 F1 points, permanently. Two upstream shapes
+ * conspired: `/pl/event-status` has one row per *date*, so three of GW1's four
+ * rows saying `leagues_updated` read as "gameweek complete"; and the live feed
+ * lists every element on zero once the fixtures exist, so counting its keys
+ * said "scored". Both are fixed in `season-state.ts` and `scoring.ts`, and
+ * `rejectUnfinalisable` now refuses the write — but the row already written had
+ * to be removed by hand.
+ *
+ * Defaults to the **sandbox** branch. `--prod` is required to touch production,
+ * and the script prints what it is about to delete either way.
+ */
+
+import { neon } from '@neondatabase/serverless';
+
+const args = process.argv.slice(2);
+const useProd = args.includes('--prod');
+const gameweek = Number(args.find((arg) => !arg.startsWith('--')));
+
+if (!Number.isInteger(gameweek) || gameweek < 1 || gameweek > 38) {
+  console.error(
+    'Usage: node --env-file=.env.local scripts/forget-gameweek.mjs <gameweek> [--prod]',
+  );
+  process.exit(1);
+}
+
+const url = useProd
+  ? process.env.NEON_CONNECTION_STRING_PROD
+  : process.env.NEON_CONNECTION_STRING_SANDBOX;
+
+const leagueId = Number(process.env.FPL_LEAGUE_ID);
+
+if (!url) {
+  console.error(
+    `${useProd ? 'NEON_CONNECTION_STRING_PROD' : 'NEON_CONNECTION_STRING_SANDBOX'} is not set.`,
+  );
+  process.exit(1);
+}
+
+if (!Number.isInteger(leagueId) || leagueId <= 0) {
+  console.error('FPL_LEAGUE_ID is not set to a positive integer.');
+  process.exit(1);
+}
+
+const sql = neon(url);
+const target = useProd ? 'PRODUCTION' : 'sandbox';
+
+// Printed before deleting, not after. The rows are the only record of what was
+// there, so a run that turns out to have been aimed at the wrong gameweek at
+// least leaves the numbers in the terminal.
+const rows = await sql`
+  select league_entry, points, rank
+  from gameweek_scores
+  where league_id = ${leagueId} and gameweek = ${gameweek}
+  order by rank
+`;
+
+if (rows.length === 0) {
+  console.log(
+    `No stored scores for GW${gameweek} in league ${leagueId} on ${target}. Nothing to do.`,
+  );
+  process.exit(0);
+}
+
+console.log(
+  `About to delete GW${gameweek} for league ${leagueId} on ${target}:`,
+);
+console.table(rows);
+
+await sql`
+  delete from gameweek_scores
+  where league_id = ${leagueId} and gameweek = ${gameweek}
+`;
+
+await sql`
+  delete from gameweeks
+  where league_id = ${leagueId} and gameweek = ${gameweek}
+`;
+
+console.log(
+  `Deleted ${rows.length} score row(s) and unmarked GW${gameweek} as finalised.`,
+);
+console.log(
+  'The next read recomputes it. Trigger one now with /api/cron/revalidate, or just load the site.',
+);

--- a/src/app/(app)/(onboarded)/(home)/page.tsx
+++ b/src/app/(app)/(onboarded)/(home)/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { getGameweekData } from '@/utils/gameweek-data';
 import { standingsByGameweek, standingsMovement } from '@/utils/scoring';
 import { StandingsTabs } from '@/components/TableView/StandingsTabs';
+import { LiveGameweekBadge } from '@/components/LiveGameweekBadge';
 import { StandingsSkeleton } from '@/components/TableView/StandingsSkeleton';
 import { SkeletonRegion } from '@/components/SkeletonRegion';
 import { PageShell } from '@/components/Layout/PageShell';
@@ -50,10 +51,18 @@ async function Standings() {
   const snapshots = standingsByGameweek(data.gameweekPerformances);
 
   return (
-    <StandingsTabs
-      data={data}
-      snapshots={snapshots}
-      movement={standingsMovement(snapshots)}
-    />
+    <div className='space-y-4'>
+      {/* Inside the boundary, not in `PageShell`'s `action` slot: whether a
+          gameweek is in flight is a fact about the data, and the heading is
+          painted before the data is read. */}
+      {data.provisionalGameweek !== null && (
+        <LiveGameweekBadge gameweek={data.provisionalGameweek} />
+      )}
+      <StandingsTabs
+        data={data}
+        snapshots={snapshots}
+        movement={standingsMovement(snapshots)}
+      />
+    </div>
   );
 }

--- a/src/app/api/cron/revalidate/route.ts
+++ b/src/app/api/cron/revalidate/route.ts
@@ -332,7 +332,13 @@ async function finaliseGameweeks(): Promise<string> {
   // happened. Writing is the point, so it goes straight to the computation.
   const season = await computeSeasonUncached();
 
-  return `${season.completedGameweeks.length} completed gameweek(s)`;
+  const finalised = season.scoredGameweeks.filter(
+    (gameweek) => gameweek !== season.provisionalGameweek,
+  );
+
+  return season.provisionalGameweek
+    ? `${finalised.length} finalised gameweek(s), GW${season.provisionalGameweek} in flight`
+    : `${finalised.length} finalised gameweek(s)`;
 }
 
 async function step(

--- a/src/components/LiveGameweekBadge.tsx
+++ b/src/components/LiveGameweekBadge.tsx
@@ -1,0 +1,51 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * "GW1 in progress" — the label on any number drawn from an unfinished gameweek.
+ *
+ * The season now includes the weekend being played, which is the whole point:
+ * a league table that ignores Sunday afternoon is wrong on the one day everyone
+ * looks at it. But a provisional F1 score rendered identically to a settled one
+ * is worse than not showing it at all, because it invites an argument that the
+ * data cannot settle. So every surface that shows one carries this.
+ *
+ * A plain server component with no client state. The dot pulses through CSS
+ * alone; `motion-safe:` keeps it still for anyone who has asked for that, and
+ * the badge still reads correctly with no animation at all.
+ */
+export function LiveGameweekBadge({
+  gameweek,
+  className,
+}: {
+  gameweek: number;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border border-positive/40 bg-positive/10 px-3 py-1 text-xs font-semibold text-positive',
+        className,
+      )}
+    >
+      <span className='relative flex h-2 w-2'>
+        <span className='absolute inline-flex h-full w-full rounded-full bg-positive opacity-60 motion-safe:animate-ping' />
+        <span className='relative inline-flex h-2 w-2 rounded-full bg-positive' />
+      </span>
+      GW{gameweek} in progress
+    </span>
+  );
+}
+
+/**
+ * The same fact as a sentence, for a card that already has a heading.
+ *
+ * Sentence case, no em dash — see the UI display rules in AGENTS.md.
+ */
+export function LiveGameweekNote({ gameweek }: { gameweek: number }) {
+  return (
+    <p className='text-xs text-muted-foreground'>
+      GW{gameweek} is still being played. These positions are provisional and
+      will change.
+    </p>
+  );
+}

--- a/src/components/TableView/DraftResultsTable.tsx
+++ b/src/components/TableView/DraftResultsTable.tsx
@@ -8,6 +8,7 @@ import { GameweekSelector } from '@/components/GameweekSelector';
 import { useViewTeam, ViewTeamDrawer } from './ViewTeamDrawer';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { LiveGameweekBadge } from '@/components/LiveGameweekBadge';
 import { TrendingUp, TrendingDown, BarChart3, Minus } from 'lucide-react';
 
 export default function DraftResultsTable({
@@ -21,10 +22,10 @@ export default function DraftResultsTable({
   // 19 flags.
   const [selectedGameweek, setSelectedGameweek] = useState<number | null>(null);
 
-  const gameweeks = data.completedGameweeks;
+  const gameweeks = data.scoredGameweeks;
   const requestedGameweek = Number(useSearchParams().get('gw'));
 
-  // `completedGameweeks` arrives newest-first.
+  // `scoredGameweeks` arrives newest-first.
   const activeGameweek =
     selectedGameweek ??
     (gameweeks.includes(requestedGameweek)
@@ -49,8 +50,12 @@ export default function DraftResultsTable({
   const formattedResults: GameweekResult[] = useMemo(() => {
     if (!activeGameweek) return [];
 
+    // No `finished` filter. The gameweek in progress is the one worth looking
+    // at on a Sunday, and hiding it left this table showing last week while the
+    // standings above it had already moved on. `isProvisional` below is how the
+    // reader is told the difference.
     const gameweekResults = data.gameweekPerformances
-      .filter((gw) => gw.event === activeGameweek && gw.finished)
+      .filter((gw) => gw.event === activeGameweek)
       .sort((a, b) => a.rank - b.rank);
 
     return gameweekResults.map((gw) => {
@@ -62,8 +67,7 @@ export default function DraftResultsTable({
         const previousRank = data.gameweekPerformances.find(
           (prevGw) =>
             prevGw.event === previousGameweek &&
-            prevGw.league_entry === gw.league_entry &&
-            prevGw.finished,
+            prevGw.league_entry === gw.league_entry,
         )?.rank;
 
         if (previousRank !== undefined) {
@@ -81,6 +85,8 @@ export default function DraftResultsTable({
       };
     });
   }, [data, activeGameweek]);
+
+  const isProvisional = activeGameweek === data.provisionalGameweek;
 
   // One drawer for the whole table; the rows only name a target.
   const viewTeam = useViewTeam(activeGameweek);
@@ -137,6 +143,8 @@ export default function DraftResultsTable({
         onSelectGameweek={selectGameweek}
       />
 
+      {isProvisional && <LiveGameweekBadge gameweek={activeGameweek} />}
+
       <BaseTable
         title=''
         subtitle=''
@@ -150,8 +158,10 @@ export default function DraftResultsTable({
       {summaryStats && (
         <Card className='border-white/10 bg-[#2a0d33]'>
           <CardHeader className='pb-3'>
+            {/* Sentence case, per the UI display rules in AGENTS.md. */}
             <CardTitle className='text-base text-white md:text-lg'>
-              Gameweek {activeGameweek} Summary
+              Gameweek {activeGameweek} summary
+              {isProvisional && ' so far'}
             </CardTitle>
           </CardHeader>
           <CardContent>

--- a/src/interfaces/fpl.ts
+++ b/src/interfaces/fpl.ts
@@ -178,10 +178,32 @@ export interface EntryPick {
 /** `/api/event/{gw}/live` — per-element stats, keyed by element ID. */
 export interface EventLive {
   /**
-   * **Empty (`{}`) for a gameweek that has not been scored**, which is truthy.
-   * Always check `Object.keys(...).length` — see agents/AGENTS.md.
+   * **Empty (`{}`) for a gameweek that has not been scored**, which is truthy —
+   * and, once the gameweek's fixtures exist, **populated with every element on
+   * zero before a ball is kicked**, which is worse. Counting the keys catches
+   * the first and not the second. Go through `hasBeenPlayed` in `scoring.ts`,
+   * which asks whether anyone has actually taken the field.
    */
-  elements: Record<string, { stats?: { total_points?: number } }>;
+  elements: Record<
+    string,
+    { stats?: { total_points?: number; minutes?: number } }
+  >;
+}
+
+/**
+ * `/api/game` — the draft game's own state.
+ *
+ * The one endpoint that answers year-round, so it is the dependable source for
+ * "which gameweek is it, and is it over?". `current_event` is `null` before the
+ * season starts. See `season-state.ts` for why `event-status` cannot answer
+ * that second question on its own.
+ */
+export interface GameState {
+  current_event: number | null;
+  current_event_finished: boolean;
+  next_event: number | null;
+  processing_status: string;
+  waivers_processed: boolean;
 }
 
 /**

--- a/src/interfaces/players.ts
+++ b/src/interfaces/players.ts
@@ -121,6 +121,14 @@ export interface GameweekPerformance {
   league_entry: LeagueEntryId;
   event_total: number;
   rank: number;
+  /**
+   * Whether this result is settled.
+   *
+   * `false` means the gameweek is still being played: the points and the rank
+   * are real and current, but they will move. Only a `true` performance may be
+   * written to the database — see `season-state.ts` for how that is decided,
+   * and `storeFinalisedGameweeks` for the guard that enforces it.
+   */
   finished: boolean;
 }
 
@@ -129,7 +137,21 @@ export interface GameweekDataResponse {
   players: PlayerDetails[];
   gameweekPerformances: GameweekPerformance[];
   currentGameweek: number;
-  completedGameweeks: number[];
+  /**
+   * Every gameweek with a result to show, newest first — **including one still
+   * being played**. Formerly `completedGameweeks`, which was a lie the moment
+   * the app started showing an in-flight week; check `provisionalGameweek` to
+   * tell them apart.
+   */
+  scoredGameweeks: number[];
+  /**
+   * The gameweek in `scoredGameweeks` that is still in progress, or `null`.
+   *
+   * Every surface that shows a rank drawn from it has to say so. A provisional
+   * F1 score presented as final is the difference between a live scoreboard and
+   * a wrong one.
+   */
+  provisionalGameweek: number | null;
   rumblerData: RumblerGameweekData[];
 }
 

--- a/src/server/data/gameweeks.ts
+++ b/src/server/data/gameweeks.ts
@@ -60,14 +60,27 @@ export async function getStoredPerformances(): Promise<GameweekPerformance[]> {
  * gameweek must stay absent so it is retried later, rather than being frozen
  * in as a set of zeros. That is the persistent version of the bug where every
  * manager tied on rank 1 and banked a win.
+ *
+ * {@link rejectUnfinalisable} makes that rule structural rather than a
+ * convention the callers are trusted to keep, and **this is the last line of
+ * defence**: the insert is `onConflictDoNothing`, so a bad row can never be
+ * corrected by a later write. A gameweek stored wrongly stays wrong until
+ * somebody deletes it by hand. Not hypothetical — GW1 of 2026/27 sat in
+ * production for three days as eight managers on zero points and joint first,
+ * paying every one of them a win and 20 F1 points.
+ *
+ * Returns the gameweeks actually written, which is not necessarily every one it
+ * was handed.
  */
 export async function storeFinalisedGameweeks(
   performances: GameweekPerformance[],
 ): Promise<number[]> {
-  if (performances.length === 0) return [];
+  const storable = rejectUnfinalisable(performances);
+
+  if (storable.length === 0) return [];
 
   const leagueId = getLeagueId();
-  const stored = [...new Set(performances.map((p) => p.event))].sort(
+  const stored = [...new Set(storable.map((p) => p.event))].sort(
     (a, b) => a - b,
   );
   const db = getDb();
@@ -75,7 +88,7 @@ export async function storeFinalisedGameweeks(
   await db
     .insert(gameweekScores)
     .values(
-      performances.map((performance) => ({
+      storable.map((performance) => ({
         leagueId,
         gameweek: performance.event,
         leagueEntry: performance.league_entry,
@@ -91,6 +104,51 @@ export async function storeFinalisedGameweeks(
     .onConflictDoNothing();
 
   return stored;
+}
+
+/**
+ * Drop any gameweek that has no business being frozen into the database.
+ *
+ * Two rules, both learned the expensive way:
+ *
+ * - **Provisional results are not facts.** `finished` is `false` while a
+ *   gameweek is being played; those rows are for display only.
+ * - **A gameweek where every manager scored 0 has not been played.** Eight
+ *   managers field eleven footballers each and any one of them on the pitch for
+ *   an hour banks two points, so a clean sweep of zeros is an unscored live
+ *   feed wearing the shape of a scored one.
+ *
+ * It **filters and logs rather than throwing**, deliberately. The caller is
+ * `computeSeasonUncached`, which every page render goes through, so a throw
+ * here would take the whole site down to prevent a write. Refusing the write is
+ * the entire job; the read carries on, the gameweek stays absent, and the next
+ * run tries again — which is what should have happened in the first place.
+ */
+function rejectUnfinalisable(
+  performances: GameweekPerformance[],
+): GameweekPerformance[] {
+  const events = new Set(performances.map((p) => p.event));
+  const refused = new Map<number, string>();
+
+  events.forEach((event) => {
+    const week = performances.filter((p) => p.event === event);
+
+    if (week.some((p) => !p.finished)) {
+      refused.set(event, 'still provisional');
+    } else if (week.every((p) => p.event_total === 0)) {
+      refused.set(event, 'every manager scored 0');
+    }
+  });
+
+  if (refused.size === 0) return performances;
+
+  refused.forEach((reason, event) => {
+    console.error(
+      `[gameweeks] Refusing to finalise GW${event}: ${reason}. It stays absent and will be retried.`,
+    );
+  });
+
+  return performances.filter((p) => !refused.has(p.event));
 }
 
 /** Remove a stored gameweek, so the next read refetches it from the API. */

--- a/src/utils/gameweek-data.ts
+++ b/src/utils/gameweek-data.ts
@@ -3,7 +3,12 @@ import type {
   GameweekDataResponse,
 } from '@/interfaces/players';
 import { GameWeekStatus } from '@/interfaces/match';
-import type { EventLive, LeagueEntry } from '@/interfaces/fpl';
+import type {
+  EventLive,
+  GameState,
+  LeagueEntry,
+  LeagueStanding,
+} from '@/interfaces/fpl';
 import {
   getFinalisedGameweeks,
   getStoredPerformances,
@@ -16,13 +21,25 @@ import {
   scoreGameweek,
   type EntryPicks,
 } from './scoring';
+import { deriveSeasonState } from './season-state';
 import { fplApi, getLeagueId } from './fpl-api';
 import { fetchEntryPicks } from './gameweek-squad';
 import { fetchLeagueDetails } from './league';
 import { cachedRead } from './cache';
 
 const CACHE_KEY = 'gameweek-data';
-const CACHE_TTL_SECONDS = 3600; // 1 hour — FPL data only changes once per gameweek
+/**
+ * Five minutes, matching the `revalidate` on the live feed and the picks below.
+ *
+ * It was an hour, on the reasoning that FPL data only changes once per
+ * gameweek. That stopped being true when the season started including the
+ * gameweek in progress: caching the aggregate for longer than its own inputs
+ * means a reader watching Sunday afternoon sees a score frozen at lunchtime,
+ * and the whole point of showing an in-flight week is that it moves. The extra
+ * cost is one league read, two state reads and nine calls for the live gameweek
+ * per five minutes, which for an eight-person league is nothing.
+ */
+const CACHE_TTL_SECONDS = 300;
 const BATCH_SIZE = 5; // fetch 5 gameweeks at a time to avoid flooding the API
 
 /**
@@ -46,10 +63,41 @@ async function fetchEventStatus(): Promise<GameWeekStatus[]> {
   return Array.isArray(body?.status) ? body.status : [];
 }
 
+/**
+ * `/api/game` — the only draft endpoint that answers year-round.
+ *
+ * Resolves to `null` rather than throwing, because it is a cross-check: without
+ * it `deriveSeasonState` falls back to `event-status` alone, which is still
+ * correct for a completed gameweek and merely defers an in-flight one. Losing
+ * the whole season because one state endpoint blipped would be the worse trade.
+ */
+async function fetchGameState(): Promise<GameState | null> {
+  try {
+    const res = await fetch(fplApi.game(), { next: { revalidate: 60 } });
+
+    if (!res.ok) return null;
+
+    const body = (await res.json()) as GameState;
+
+    return typeof body?.current_event_finished === 'boolean' ? body : null;
+  } catch (error) {
+    console.error('[season] /api/game could not be read.', error);
+    return null;
+  }
+}
+
+/**
+ * Score a contiguous run of gameweeks from the live feed and everyone's picks.
+ *
+ * `finished` is threaded straight through to `scoreGameweek` and is what marks
+ * the results as safe to persist. The in-flight gameweek goes through this same
+ * function with `false`.
+ */
 async function fetchGameweekBatch(
   startGw: number,
   endGw: number,
   leagueEntries: LeagueEntry[],
+  finished: boolean,
 ): Promise<GameweekPerformance[]> {
   const batchPromises = [];
 
@@ -89,7 +137,7 @@ async function fetchGameweekBatch(
   // `scoreGameweek` returns nothing for a gameweek that cannot be scored, so an
   // unplayed week falls out of the results rather than being stored as zeros.
   return results.flatMap(({ gameweek, liveData, playerPicks }) =>
-    scoreGameweek(gameweek, liveData, playerPicks),
+    scoreGameweek(gameweek, liveData, playerPicks, finished),
   );
 }
 
@@ -119,6 +167,8 @@ async function fetchMissingGameweeks(
       batch[0],
       batch[batch.length - 1],
       leagueEntries,
+      // Only ever called with gameweeks `deriveSeasonState` has declared final.
+      true,
     );
     fetched.push(...batchData.filter((p) => missing.includes(p.event)));
   }
@@ -129,9 +179,10 @@ async function fetchMissingGameweeks(
 /**
  * Compute the season from scratch: upstream, database, scoring, aggregation.
  *
- * Expensive — two upstream calls and two database round trips before any
- * gameweek work, which measured ~2s from here. Readers always reach it through
- * `getGameweekData()`, never directly.
+ * Expensive — three upstream calls and two database round trips before any
+ * gameweek work, which measured ~2s from here, plus nine more calls whenever a
+ * gameweek is in flight. Readers always reach it through `getGameweekData()`,
+ * never directly.
  *
  * Exported only for the sync job, which must **not** go through the cache: its
  * whole purpose is to write any newly finalised gameweek, and a cache hit would
@@ -142,34 +193,33 @@ export async function computeSeasonUncached(): Promise<GameweekDataResponse> {
   const leagueId = getLeagueId();
 
   // The two database reads are keyed off the league alone, so they do not
-  // wait on the upstream calls — issuing all four together removes a serial
+  // wait on the upstream calls — issuing all five together removes a serial
   // Neon round trip, which measured 290-650ms, from every cold read.
-  const [{ league_entries, standings }, status, finalised, storedPerformances] =
-    await Promise.all([
-      fetchLeagueDetails(leagueId),
-      fetchEventStatus(),
-      getFinalisedGameweeks(),
-      getStoredPerformances(),
-    ]);
+  const [
+    { league_entries, standings },
+    status,
+    game,
+    finalised,
+    storedPerformances,
+  ] = await Promise.all([
+    fetchLeagueDetails(leagueId),
+    fetchEventStatus(),
+    fetchGameState(),
+    getFinalisedGameweeks(),
+    getStoredPerformances(),
+  ]);
 
-  // Derive max gameweek from status array — instant, no extra HTTP calls
-  const maxGameweek = Math.max(...status.map((s) => s.event), 0);
-  const completedEvents = status.filter((s) => s.leagues_updated);
-  const maxCompletedGameweek =
-    completedEvents.length > 0
-      ? Math.max(...completedEvents.map((s) => s.event))
-      : 0;
+  // The one place "is this gameweek over?" is decided. Read `season-state.ts`
+  // before touching it: `event-status` has a row per **date**, so the obvious
+  // `some(leagues_updated)` reading declares a gameweek complete on its opening
+  // Friday night.
+  const { currentGameweek, finalisedThrough } = deriveSeasonState(status, game);
 
-  const currentEvent = maxGameweek;
-  const isCurrentFinished = completedEvents.some(
-    (s) => s.event === currentEvent,
-  );
-
-  const throughGameweek = maxCompletedGameweek || maxGameweek;
-
-  // Fetch only the gap between what we hold and what has been played.
+  // Fetch only the gap between what we hold and what is genuinely settled.
+  // Nothing in flight ever reaches this list — a stored gameweek is never
+  // refetched, so storing a provisional one freezes it for the season.
   const missing: number[] = [];
-  for (let gw = 1; gw <= throughGameweek; gw++) {
+  for (let gw = 1; gw <= finalisedThrough; gw++) {
     if (!finalised.has(gw)) missing.push(gw);
   }
 
@@ -182,49 +232,118 @@ export async function computeSeasonUncached(): Promise<GameweekDataResponse> {
     await storeFinalisedGameweeks(freshPerformances);
   }
 
-  const historicalData = [...storedPerformances, ...freshPerformances];
+  // The gameweek being played right now, scored fresh on every cache miss and
+  // deliberately never written down.
+  //
+  // **Shown, not hidden.** A league table that ignores the weekend in progress
+  // is wrong on the one day everybody looks at it, so the provisional result
+  // ranks and pays F1 points exactly like a settled one; the surfaces that show
+  // it say that it is provisional. What it must never do is persist, because
+  // `gameweeks` is a claim that a result will never change again.
+  const inFlight = currentGameweek > finalisedThrough ? currentGameweek : null;
 
-  // Fallback for the just-finished gameweek when its live data or picks
-  // aren't retrievable. Deliberately not persisted: `standings[].event_total`
-  // is a different source from the starting-XI sum we store everywhere else,
-  // and mixing the two in the cache would make the history inconsistent.
-  // Leaving it out means this gameweek is retried next run, which is correct.
-  if (isCurrentFinished && standings) {
-    const hasCurrentGameweekData = historicalData.some(
-      (gw) => gw.event === currentEvent,
-    );
+  const provisional = inFlight
+    ? await fetchGameweekBatch(inFlight, inFlight, league_entries, false)
+    : [];
 
-    if (!hasCurrentGameweekData) {
-      const currentGameweekData = standings.map((standing) => ({
-        league_entry: standing.league_entry,
-        event_total: standing.event_total,
-      }));
+  const historicalData = [
+    ...withoutInFlight(storedPerformances, inFlight, provisional.length > 0),
+    ...freshPerformances,
+    ...provisional,
+  ];
 
-      const rankedCurrentData = assignRanks(currentGameweekData);
+  // Last resort for the current gameweek when its live feed or its picks are
+  // unreadable: upstream's own `event_total`, which is a different source from
+  // the starting-XI sum stored everywhere else. Provisional for that reason as
+  // much as any other — it is never persisted, so the two sources cannot mix in
+  // the history, and the gameweek is retried on the next run.
+  const fallback = standingsFallback(
+    standings,
+    currentGameweek,
+    historicalData,
+  );
 
-      rankedCurrentData.forEach((player) => {
-        historicalData.push({
-          event: currentEvent,
-          league_entry: player.league_entry,
-          event_total: player.event_total,
-          rank: player.rank,
-          finished: true,
-        });
-      });
-    }
-  }
+  historicalData.push(...fallback);
 
-  const completedGameweeks = Array.from(
+  const provisionalGameweek =
+    provisional.length > 0 || fallback.length > 0 ? currentGameweek : null;
+
+  const scoredGameweeks = Array.from(
     new Set(historicalData.map((gw) => gw.event)),
   ).sort((a, b) => b - a);
 
   return {
     players: aggregatePlayers(league_entries, historicalData, standings),
     gameweekPerformances: historicalData,
-    currentGameweek: currentEvent,
-    completedGameweeks,
+    currentGameweek,
+    scoredGameweeks,
+    provisionalGameweek,
     rumblerData: buildRumblerData(historicalData, league_entries),
   };
+}
+
+/**
+ * Drop stored rows for a gameweek that is still being played.
+ *
+ * There should never be any: a gameweek is only written once
+ * `deriveSeasonState` calls it final. But the whole reason this file changed is
+ * that the app used to write one on the opening Friday night, and those rows
+ * cannot be corrected by a later run — `storeFinalisedGameweeks` inserts with
+ * `onConflictDoNothing`. Left in place they would sit beside the live scoring
+ * for the same gameweek and every manager would appear twice.
+ *
+ * So the live scoring wins and the stale rows are logged, loudly, because the
+ * fix is a `scripts/forget-gameweek.mjs` run that nobody will make if the
+ * symptom quietly disappears. `replaced` guards against the other direction:
+ * with nothing to replace them, keeping the rows beats blanking the gameweek.
+ */
+function withoutInFlight(
+  stored: GameweekPerformance[],
+  inFlight: number | null,
+  replaced: boolean,
+): GameweekPerformance[] {
+  if (inFlight === null || !replaced) return stored;
+  if (!stored.some((gw) => gw.event === inFlight)) return stored;
+
+  console.error(
+    `[season] GW${inFlight} is stored as finalised but is still being played. ` +
+      'Using the live scoring; delete the stored rows with ' +
+      `\`node --env-file=.env.local scripts/forget-gameweek.mjs ${inFlight} --prod\`.`,
+  );
+
+  return stored.filter((gw) => gw.event !== inFlight);
+}
+
+/**
+ * The current gameweek reconstructed from `standings[].event_total`, or nothing.
+ *
+ * Only fires when the gameweek is genuinely absent from the results, and only
+ * when somebody has actually scored. That second guard is the important one:
+ * post-draft and pre-kick-off, upstream returns a full row per manager with
+ * `event_total: 0`, and ranking eight zeros is precisely the joint-first bug
+ * that this whole change exists to stop.
+ */
+function standingsFallback(
+  standings: LeagueStanding[] | undefined,
+  currentGameweek: number,
+  performances: GameweekPerformance[],
+): GameweekPerformance[] {
+  if (!standings || currentGameweek <= 0) return [];
+  if (performances.some((gw) => gw.event === currentGameweek)) return [];
+  if (!standings.some((standing) => standing.event_total > 0)) return [];
+
+  return assignRanks(
+    standings.map((standing) => ({
+      league_entry: standing.league_entry,
+      event_total: standing.event_total,
+    })),
+  ).map((player) => ({
+    event: currentGameweek,
+    league_entry: player.league_entry,
+    event_total: player.event_total,
+    rank: player.rank,
+    finished: false,
+  }));
 }
 
 /**

--- a/src/utils/player-profile.ts
+++ b/src/utils/player-profile.ts
@@ -50,9 +50,12 @@ export function buildPlayerProfile(
 
   if (!player) return null;
 
+  // The gameweek in progress counts, exactly as it does in the standings and on
+  // the results table. It has to: `f1_score` on the player already includes it,
+  // so filtering it out here would show a manager 20 F1 points from a season of
+  // "0 gameweeks played". One season, one set of numbers.
   const gameweeks = data.gameweekPerformances.filter(
-    (performance) =>
-      performance.league_entry === leagueEntry && performance.finished,
+    (performance) => performance.league_entry === leagueEntry,
   );
 
   return {

--- a/src/utils/scoring.test.ts
+++ b/src/utils/scoring.test.ts
@@ -21,6 +21,7 @@ import {
   buildLeagueLedger,
   buildPointsSpread,
   buildRumblerData,
+  hasBeenPlayed,
   rankByPoints,
   scoreGameweek,
   standingsByGameweek,
@@ -47,11 +48,29 @@ function makeEntries(count: number): LeagueEntry[] {
   }));
 }
 
-/** A live feed where element `n` scored `n` points. */
+/** A live feed where element `n` scored `n` points, having played 90 minutes. */
 function makeLive(elementIds: ElementId[]): EventLive {
   return {
     elements: Object.fromEntries(
-      elementIds.map((id) => [String(id), { stats: { total_points: id } }]),
+      elementIds.map((id) => [
+        String(id),
+        { stats: { total_points: id, minutes: 90 } },
+      ]),
+    ),
+  };
+}
+
+/**
+ * The shape that broke GW1 of 2026/27: every element in the game listed, all of
+ * them on zero, hours before the first kick-off. Truthy, and 609 keys long.
+ */
+function makeUnplayedLive(elementIds: ElementId[]): EventLive {
+  return {
+    elements: Object.fromEntries(
+      elementIds.map((id) => [
+        String(id),
+        { stats: { total_points: 0, minutes: 0 } },
+      ]),
     ),
   };
 }
@@ -125,7 +144,7 @@ describe('scoreGameweek', () => {
 
   it('sums the starting XI only, ignoring the bench', () => {
     // Every pick is element 1, worth 1 point. 15 picks, 11 of them starters.
-    const scored = scoreGameweek(1, makeLive([asElementId(1)]), picks);
+    const scored = scoreGameweek(1, makeLive([asElementId(1)]), picks, true);
 
     expect(scored).toHaveLength(3);
     expect(scored.every((p) => p.event_total === 11)).toBe(true);
@@ -134,26 +153,98 @@ describe('scoreGameweek', () => {
   it('returns nothing when the live feed is an empty object', () => {
     // `{}` is truthy. Without the key count every manager scores 0, ties on
     // rank 1, and banks a win for a gameweek that has not been played.
-    expect(scoreGameweek(1, { elements: {} }, picks)).toEqual([]);
+    expect(scoreGameweek(1, { elements: {} }, picks, true)).toEqual([]);
   });
 
   it('returns nothing when the live request failed', () => {
-    expect(scoreGameweek(1, null, picks)).toEqual([]);
+    expect(scoreGameweek(1, null, picks, true)).toEqual([]);
   });
 
   it('returns nothing when no manager has picks', () => {
     const empty = entries.map((e) => ({ league_entry: e.id, picks: [] }));
-    expect(scoreGameweek(1, makeLive([asElementId(1)]), empty)).toEqual([]);
+    expect(scoreGameweek(1, makeLive([asElementId(1)]), empty, true)).toEqual(
+      [],
+    );
   });
 
   it('scores an element missing from the live feed as zero, not NaN', () => {
-    const scored = scoreGameweek(1, makeLive([asElementId(999)]), picks);
+    const scored = scoreGameweek(1, makeLive([asElementId(999)]), picks, true);
     expect(scored.every((p) => p.event_total === 0)).toBe(true);
   });
 
   it('stamps every performance with the gameweek it came from', () => {
-    const scored = scoreGameweek(7, makeLive([asElementId(1)]), picks);
+    const scored = scoreGameweek(7, makeLive([asElementId(1)]), picks, true);
     expect(scored.every((p) => p.event === 7)).toBe(true);
+  });
+
+  it('returns nothing when the live feed is full but nobody has played', () => {
+    // The GW1 2026/27 bug, exactly. `elements` has 609 keys, so the key count
+    // says "scored"; every manager sums to 0, ties on rank 1, banks a win and
+    // 20 F1 points — and the caller then wrote it to the database as final.
+    const unplayed = makeUnplayedLive([
+      asElementId(1),
+      asElementId(2),
+      asElementId(3),
+    ]);
+
+    expect(scoreGameweek(1, unplayed, picks, true)).toEqual([]);
+  });
+
+  it('scores a gameweek where one element has played and the rest have not', () => {
+    // The other half of the same rule: a gameweek two minutes old is a real
+    // gameweek. Only *nothing at all* means "not started".
+    const live: EventLive = {
+      elements: {
+        '1': { stats: { total_points: 0, minutes: 12 } },
+        '2': { stats: { total_points: 0, minutes: 0 } },
+      },
+    };
+
+    expect(scoreGameweek(1, live, picks, true)).toHaveLength(3);
+  });
+
+  it('carries the finished flag onto every performance', () => {
+    // What decides whether the caller may persist the gameweek.
+    const live = makeLive([asElementId(1)]);
+
+    expect(
+      scoreGameweek(1, live, picks, false).every((p) => p.finished === false),
+    ).toBe(true);
+    expect(
+      scoreGameweek(1, live, picks, true).every((p) => p.finished === true),
+    ).toBe(true);
+  });
+});
+
+describe('hasBeenPlayed', () => {
+  it('is false for an absent feed and an empty one', () => {
+    expect(hasBeenPlayed(null)).toBe(false);
+    expect(hasBeenPlayed({ elements: {} })).toBe(false);
+  });
+
+  it('is false for a full feed of untouched elements', () => {
+    expect(
+      hasBeenPlayed(makeUnplayedLive([asElementId(1), asElementId(2)])),
+    ).toBe(false);
+  });
+
+  it('is true as soon as one element has minutes, even on zero points', () => {
+    expect(
+      hasBeenPlayed({ elements: { '1': { stats: { minutes: 3 } } } }),
+    ).toBe(true);
+  });
+
+  it('is true on points alone, in case a feed omits minutes', () => {
+    expect(
+      hasBeenPlayed({ elements: { '1': { stats: { total_points: 6 } } } }),
+    ).toBe(true);
+  });
+
+  it('is true for a negative score, which is a real result', () => {
+    // A red card can put a manager's element below zero. `!== 0`, not `> 0`.
+    expect(
+      hasBeenPlayed({ elements: { '1': { stats: { total_points: -1 } } } }),
+    ).toBe(true);
   });
 });
 

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -15,6 +15,10 @@
  *   managers a joint first and 20 points each.
  * - **Upstream says "nothing yet" with `{}` and `[]`, both truthy.** Count keys,
  *   never test truthiness.
+ * - **A full `elements` map of zeros is also "nothing yet".** Counting keys is
+ *   not enough: once a gameweek's fixtures exist, the live feed lists all ~609
+ *   elements with `minutes: 0` and `total_points: 0` hours before kick-off.
+ *   That is the shape that actually shipped the joint-first bug in August 2026.
  * - **Ties share the higher rank and consume the lower ones.** Two managers tied
  *   at the top are both rank 1 and the next is rank 3, so both bank a win.
  */
@@ -67,27 +71,62 @@ export function assignRanks<T extends { event_total: number }>(
 }
 
 /**
+ * Has anyone actually taken the field in this gameweek?
+ *
+ * The question the old `Object.keys(elements).length === 0` guard was trying to
+ * ask, and the one it could not answer. Upstream has two distinct "nothing yet"
+ * shapes and they arrive in sequence:
+ *
+ * 1. Before the gameweek's fixtures exist, `elements` is `{}`.
+ * 2. Once they exist — hours before the first kick-off — `elements` lists every
+ *    element in the game with `minutes: 0` and `total_points: 0`.
+ *
+ * The second is indistinguishable from a scored gameweek by key count alone,
+ * and it is the one that corrupted GW1 of 2026/27: eight managers summed to 0,
+ * tied on rank 1, and were written to the database as final.
+ *
+ * `minutes` is the signal rather than `total_points`, because a footballer can
+ * legitimately score 0 while a footballer who has not played cannot have
+ * minutes. `total_points` is checked too, purely so a feed that omits `minutes`
+ * cannot make a genuinely played gameweek look empty.
+ */
+export function hasBeenPlayed(liveData: EventLive | null): boolean {
+  if (!liveData?.elements) return false;
+
+  return Object.values(liveData.elements).some(
+    (element) =>
+      (element?.stats?.minutes ?? 0) > 0 ||
+      (element?.stats?.total_points ?? 0) !== 0,
+  );
+}
+
+/**
  * Score one gameweek from its live feed and every manager's picks.
  *
  * Returns an **empty array** when the gameweek cannot be scored, and the caller
- * must treat that as "not played yet" and store nothing. Three ways that
+ * must treat that as "not played yet" and store nothing. Four ways that
  * happens, all of which look like a scored gameweek to a careless check:
  *
  * 1. `liveData` is null — the request failed.
- * 2. `liveData.elements` is `{}` — the gameweek exists but has not been scored.
- *    `{}` is truthy, so only the key count catches this.
- * 3. Nobody's picks loaded — scoring the survivors would rank a partial league.
+ * 2. `liveData.elements` is `{}` — the fixtures do not exist yet. `{}` is
+ *    truthy, so only the key count catches this.
+ * 3. `liveData.elements` is full but nobody has played a minute — see
+ *    {@link hasBeenPlayed}. The key count does **not** catch this.
+ * 4. Nobody's picks loaded — scoring the survivors would rank a partial league.
  *
- * Only positions 1–11 count; 12–15 are the bench.
+ * `finished` says whether the result is settled. It is the flag that decides
+ * whether the caller may persist the gameweek, so it is a required argument
+ * rather than a defaulted one: a caller that has not thought about it has to
+ * say so out loud. Only positions 1–11 count; 12–15 are the bench.
  */
 export function scoreGameweek(
   gameweek: number,
   liveData: EventLive | null,
   playerPicks: EntryPicks[],
+  finished: boolean,
 ): GameweekPerformance[] {
-  if (!liveData?.elements || Object.keys(liveData.elements).length === 0) {
-    return [];
-  }
+  // `liveData &&` first so the compiler narrows it for the closure below.
+  if (!liveData || !hasBeenPlayed(liveData)) return [];
 
   const scoredEntries = playerPicks.filter(
     (playerData) => playerData?.picks?.length,
@@ -118,7 +157,7 @@ export function scoreGameweek(
     league_entry: player.league_entry,
     event_total: player.event_total,
     rank: player.rank,
-    finished: true,
+    finished,
   }));
 }
 

--- a/src/utils/season-state.test.ts
+++ b/src/utils/season-state.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GameState } from '@/interfaces/fpl';
+import type { GameWeekStatus } from '@/interfaces/match';
+import { deriveSeasonState } from './season-state';
+
+/** One `event-status` row. Remember: a row is a **date**, not a gameweek. */
+function row(
+  event: number,
+  date: string,
+  leaguesUpdated: boolean,
+): GameWeekStatus {
+  return {
+    bonus_added: leaguesUpdated,
+    date,
+    event,
+    leagues_updated: leaguesUpdated,
+    points: leaguesUpdated ? 'r' : '',
+  };
+}
+
+function game(currentEvent: number | null, finished: boolean): GameState {
+  return {
+    current_event: currentEvent,
+    current_event_finished: finished,
+    next_event: currentEvent === null ? 1 : currentEvent + 1,
+    processing_status: 'n',
+    waivers_processed: false,
+  };
+}
+
+/**
+ * The exact payload observed on 2026-08-24, mid-GW1: four match days, three of
+ * them already scored, one game left to play.
+ */
+const GW1_IN_PROGRESS: GameWeekStatus[] = [
+  row(1, '2026-08-21', true),
+  row(1, '2026-08-22', true),
+  row(1, '2026-08-23', true),
+  row(1, '2026-08-24', false),
+];
+
+describe('deriveSeasonState', () => {
+  it('does not finalise a gameweek whose match days are only partly scored', () => {
+    // The bug, in one assertion. `status.some((s) => s.leagues_updated)` is
+    // true here — three of the four rows say so — and reading it that way
+    // declared GW1 complete on the Friday night, wrote eight managers on zero
+    // points into the database as final, and paid every one of them a win and
+    // 20 F1 points.
+    expect(deriveSeasonState(GW1_IN_PROGRESS, game(1, false))).toEqual({
+      currentGameweek: 1,
+      finalisedThrough: 0,
+    });
+  });
+
+  it('finalises a gameweek once every match day and the game agree', () => {
+    const done = GW1_IN_PROGRESS.map((r) => ({ ...r, leagues_updated: true }));
+
+    expect(deriveSeasonState(done, game(1, true))).toEqual({
+      currentGameweek: 1,
+      finalisedThrough: 1,
+    });
+  });
+
+  it('waits for league scoring even after the last whistle', () => {
+    // `current_event_finished` flips when the football stops; `leagues_updated`
+    // flips when the draft league has actually been scored, bonus included.
+    // Finalising on the first alone stores a gameweek without its bonus points.
+    expect(deriveSeasonState(GW1_IN_PROGRESS, game(1, true))).toEqual({
+      currentGameweek: 1,
+      finalisedThrough: 0,
+    });
+  });
+
+  it('waits for the game even after every match day is scored', () => {
+    const done = GW1_IN_PROGRESS.map((r) => ({ ...r, leagues_updated: true }));
+
+    expect(deriveSeasonState(done, game(1, false))).toEqual({
+      currentGameweek: 1,
+      finalisedThrough: 0,
+    });
+  });
+
+  it('treats every gameweek below the current one as settled', () => {
+    // `event-status` only carries the current gameweek's dates, so nothing in
+    // it can speak for GW1-4. The game moving on is the evidence.
+    const state = deriveSeasonState(
+      [row(5, '2026-09-19', false)],
+      game(5, false),
+    );
+
+    expect(state).toEqual({ currentGameweek: 5, finalisedThrough: 4 });
+  });
+
+  it('is an empty season before the first gameweek', () => {
+    // Pre-season: `event-status` 404s to `[]` and `current_event` is null.
+    expect(deriveSeasonState([], game(null, false))).toEqual({
+      currentGameweek: 0,
+      finalisedThrough: 0,
+    });
+  });
+
+  it('falls back to the status rows when /api/game cannot be read', () => {
+    expect(deriveSeasonState(GW1_IN_PROGRESS, null)).toEqual({
+      currentGameweek: 1,
+      finalisedThrough: 0,
+    });
+
+    const done = GW1_IN_PROGRESS.map((r) => ({ ...r, leagues_updated: true }));
+    expect(deriveSeasonState(done, null)).toEqual({
+      currentGameweek: 1,
+      finalisedThrough: 1,
+    });
+  });
+
+  it('does not finalise a gameweek it has no status rows for', () => {
+    // "We cannot tell" is not "finished". `every` on an empty list is `true`,
+    // which is exactly the trap this guards.
+    expect(deriveSeasonState([], game(3, true))).toEqual({
+      currentGameweek: 3,
+      finalisedThrough: 2,
+    });
+  });
+
+  it('ignores rows belonging to other gameweeks', () => {
+    // A payload carrying the tail of GW1 and the start of GW2 must not let
+    // GW1's finished rows finalise GW2.
+    const mixed = [row(1, '2026-08-24', true), row(2, '2026-08-29', false)];
+
+    expect(deriveSeasonState(mixed, game(2, false))).toEqual({
+      currentGameweek: 2,
+      finalisedThrough: 1,
+    });
+  });
+});

--- a/src/utils/season-state.ts
+++ b/src/utils/season-state.ts
@@ -1,0 +1,101 @@
+/**
+ * Which gameweek is in play, and which gameweeks are actually over.
+ *
+ * Pure, and separated out for the same reason `scoring.ts` is: this is the
+ * decision that says whether a result may be written to the database and never
+ * looked at again. It got that decision wrong on the first weekend of the
+ * 2026/27 season, and the cost was a permanently corrupted GW1.
+ *
+ * ## `/pl/event-status` has one row per **date**, not per gameweek
+ *
+ * This is the trap. The field names read like a gameweek summary and the
+ * payload is a gameweek's *match days*:
+ *
+ * ```jsonc
+ * { "status": [
+ *   { "date": "2026-08-21", "event": 1, "leagues_updated": true,  "points": "p" },
+ *   { "date": "2026-08-22", "event": 1, "leagues_updated": true,  "points": "p" },
+ *   { "date": "2026-08-23", "event": 1, "leagues_updated": true,  "points": "p" },
+ *   { "date": "2026-08-24", "event": 1, "leagues_updated": false, "points": ""  },
+ * ] }
+ * ```
+ *
+ * `leagues_updated` means "the league table was brought up to date after *that
+ * day's* matches" — not "this gameweek is final". So
+ * `status.filter((s) => s.leagues_updated)` reports GW1 complete on the Friday
+ * night, with three days of football still to play. That is what the app did,
+ * and combined with a live feed that was all zeros before kick-off it wrote
+ * eight managers on 0 points, all tied on rank 1, straight into
+ * `gameweek_scores` — where a finalised gameweek is never refetched. Every
+ * manager banked a win and 20 F1 points, permanently.
+ *
+ * ## The rule
+ *
+ * A gameweek is final when **both** sources agree, and `/api/game` is the
+ * senior of the two because it answers year-round and says exactly one thing:
+ *
+ * - Any gameweek **below** `current_event` is over — the game has moved on.
+ * - `current_event` is over only when `current_event_finished` is true **and**
+ *   every one of its `event-status` rows has `leagues_updated`.
+ *
+ * The second half is not redundant. `current_event_finished` flips when the
+ * last whistle blows; `leagues_updated` flips when the draft league's scoring
+ * has actually been processed, bonus points included. Waiting for both means a
+ * gameweek is occasionally finalised one cron run later than it could have
+ * been, which costs nothing — the in-flight path still shows it — while the
+ * opposite mistake is unrecoverable without a manual delete.
+ */
+import type { GameWeekStatus } from '@/interfaces/match';
+import type { GameState } from '@/interfaces/fpl';
+
+export interface SeasonState {
+  /**
+   * The gameweek being played, or the most recent one if none is in progress.
+   * `0` before the season starts.
+   */
+  currentGameweek: number;
+  /**
+   * The highest gameweek whose scoring is final and therefore safe to store.
+   * `0` when none is — including all through the opening gameweek.
+   */
+  finalisedThrough: number;
+}
+
+/**
+ * Derive the season's position from the two upstream state endpoints.
+ *
+ * `game` is `null` when `/api/game` could not be read. The fallback is
+ * deliberately the pessimistic one: without it, a gameweek is final only if
+ * every `event-status` row for it says so, which is still correct for a
+ * completed gameweek and simply defers an in-flight one.
+ */
+export function deriveSeasonState(
+  status: GameWeekStatus[],
+  game: GameState | null,
+): SeasonState {
+  const statusMax = status.reduce((max, row) => Math.max(max, row.event), 0);
+
+  // `current_event` is `null` pre-season, and `event-status` 404s to `[]` at
+  // the same time, so both being absent means the season has not started.
+  const currentGameweek = game?.current_event ?? statusMax;
+
+  if (currentGameweek <= 0) return { currentGameweek: 0, finalisedThrough: 0 };
+
+  const rows = status.filter((row) => row.event === currentGameweek);
+
+  // Every row, not some row — see the module comment. No rows at all is "we
+  // cannot tell", which is not the same as "finished".
+  const leagueScoringDone =
+    rows.length > 0 && rows.every((row) => row.leagues_updated);
+
+  // Without `/api/game` the status rows are all we have. With it, its verdict
+  // has to agree.
+  const currentIsFinal = game
+    ? game.current_event_finished && leagueScoringDone
+    : leagueScoringDone;
+
+  return {
+    currentGameweek,
+    finalisedThrough: currentIsFinal ? currentGameweek : currentGameweek - 1,
+  };
+}


### PR DESCRIPTION
## The bug

Everyone had the same F1 score — all eight managers on 20 points and a win each — because GW1 was written to the database **on the Friday evening, before a ball was kicked**, as eight managers on zero points, all tied on rank 1. A finalised gameweek is never refetched, so it served that for three days.

Two upstream shapes conspired, neither of which the existing guards catch:

- **`/pl/event-status` has one row per _date_, not per gameweek.** GW1 had four rows (21st–24th Aug); three said `leagues_updated: true` because *those days'* matches had been scored. `status.some((s) => s.leagues_updated)` therefore read as "gameweek complete" with three days of football still to play.
- **`/event/{gw}/live` lists all 609 elements on `minutes: 0`** from the moment the gameweek's fixtures exist — hours before kick-off. `Object.keys(elements).length === 0` catches `{}` and not this.

The third problem sat underneath both: `throughGameweek = maxCompletedGameweek || maxGameweek` fell back to the *in-flight* gameweek, so an unfinished week could always reach `storeFinalisedGameweeks`.

## The fixes

- **`deriveSeasonState()`** (new `src/utils/season-state.ts`, fully tested) is now the only place that decides whether a gameweek is over. Below `current_event` it is; `current_event` itself only when `/api/game` reports `current_event_finished` **and** every status row for it says `leagues_updated`.
- **`hasBeenPlayed()`** replaces the key count — it asks whether anyone has actually taken the field, rather than whether the container is populated.
- **`storeFinalisedGameweeks` refuses** anything provisional, and any gameweek where every manager scored 0. It filters and logs rather than throwing, because every page render goes through its caller.
- **The gameweek in flight is now shown, not hidden.** Scored by the same rule, marked `finished: false`, named in `provisionalGameweek`, never stored. The standings and results table both label it "GW1 in progress". Ignoring the weekend being played made the site wrong on the one day anyone looks at it; showing it as settled would have been worse.
- `completedGameweeks` → `scoredGameweeks`, because it now includes a gameweek that is not complete.
- Season cache TTL drops 1h → 5m, matching the `revalidate` on its own inputs. A live score frozen at lunchtime is not live.
- `scripts/forget-gameweek.mjs` is the escape hatch for a row already written — `onConflictDoNothing` means no amount of correct code removes one.

## Verified

Against today's real upstream data and the production database:

```
season state: { currentGameweek: 1, finalisedThrough: 0 }  |  live GW1 played? true
would fetch+store: []        <- nothing persisted, correct
in-flight gameweek: 1
Japie 68 (1st, 20)  Theunis 40 (2nd, 15)  Mossi 36 (3rd, 12)
Johan 27 (4th, 10)  Ian 27 (4th, 10)  Mark 26 (6th, 6)
Nick 24 (7th, 4)  Kobie 16 (8th, 2)
```

Also ran the real cron route locally (`finalise: "9 finalised gameweek(s), GW1 in flight"`), confirming nothing new was written and the stored/in-flight collision is detected and logged with the exact repair command.

`pnpm lint` (0 errors, the 2 known warnings), `typecheck`, `test` (159 pass) and `build` all green. **Layout changes are verified by eye, not by CI** — the new `LiveGameweekBadge` on the standings page and results table.

## Deploy note

The corrupt GW1 rows have already been deleted from production. Until this is deployed, the old code will re-store GW1 mid-flight on the next page load — rerun `node --env-file=.env.local scripts/forget-gameweek.mjs 1 --prod` after deploying if that happens.

## Docs

`agents/API.md` and `agents/AGENTS.md` both updated with the observed payloads and the new law ("A gameweek is over when two sources agree, and never before").

🤖 Generated with [Claude Code](https://claude.com/claude-code)